### PR TITLE
Add preliminary JSONPath Array support

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -108,16 +108,15 @@ double round2(double value) {
 
 JsonVariant resolveJsonPath(JsonVariant variant, const char* path) {
   for (size_t n = 0; path[n]; n++) {
+    // Not a full array support, but works for Shelly 3EM emeters array!    
     if (path[n] == '[') {
       variant = variant[JsonString(path, n)][atoi(&path[n+1])];
       path += n + 4;
       n = 0;
     }
     if (path[n] == '.' ) {
-      DEBUG_SERIAL.println(path);
       variant = variant[JsonString(path, n)];
       path += n + 1;
-      DEBUG_SERIAL.println(path);
       n = 0;
     }
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -786,6 +786,7 @@ void setup(void) {
 
   // Set up MQTT
   if(dataMQTT) {
+    mqtt_client.setBufferSize(2048);
     mqtt_client.setServer(mqtt_server, String(mqtt_port).toInt());
     mqtt_client.setCallback(mqtt_callback);
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -108,9 +108,16 @@ double round2(double value) {
 
 JsonVariant resolveJsonPath(JsonVariant variant, const char* path) {
   for (size_t n = 0; path[n]; n++) {
-    if (path[n] == '.') {
+    if (path[n] == '[') {
+      variant = variant[JsonString(path, n)][atoi(&path[n+1])];
+      path += n + 4;
+      n = 0;
+    }
+    if (path[n] == '.' ) {
+      DEBUG_SERIAL.println(path);
       variant = variant[JsonString(path, n)];
       path += n + 1;
+      DEBUG_SERIAL.println(path);
       n = 0;
     }
   }


### PR DESCRIPTION
Add simple array support so Shelly 3EM can be used via generic HTTP interface. Still not a full JSONPath implementation!

See #11 