### PR TITLE
Add optional internal LED blink on HTTP request with configurable GPIO via web interface

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,6 +46,7 @@ char query_period[10] = "1000";
 
 unsigned long ledOffTime = 0;
 int led = 0;
+int ledblinkduration = 50;
 char led_gpio[2] = "";
 
 unsigned long period = 1000;
@@ -241,7 +242,7 @@ void GetDeviceInfo() {
   jsonResponse["profile"] = "triphase";
   serializeJson(jsonResponse,serJsonResponse);
   DEBUG_SERIAL.println(serJsonResponse);
-  blinkled(50);
+  blinkled(ledblinkduration);
 }
 
 void EMGetStatus(){
@@ -270,7 +271,7 @@ void EMGetStatus(){
   jsonResponse["total_aprt_power"] = PhasePower[0].apparentPower + PhasePower[1].apparentPower + PhasePower[2].apparentPower;
   serializeJson(jsonResponse,serJsonResponse);
   DEBUG_SERIAL.println(serJsonResponse);
-  blinkled(50);
+  blinkled(ledblinkduration);
 }
 
 void EMDataGetStatus() {
@@ -286,7 +287,7 @@ void EMDataGetStatus() {
   jsonResponse["total_act_ret"] = PhaseEnergy[0].gridfeedin + PhaseEnergy[1].gridfeedin + PhaseEnergy[2].gridfeedin;
   serializeJson(jsonResponse,serJsonResponse);
   DEBUG_SERIAL.println(serJsonResponse);
-  blinkled(50);
+  blinkled(ledblinkduration);
 }
 
 void EMGetConfig() {
@@ -299,7 +300,7 @@ void EMGetConfig() {
   jsonResponse["ct_type"] = "120A";
   serializeJson(jsonResponse,serJsonResponse);
   DEBUG_SERIAL.println(serJsonResponse);
-  blinkled(50);
+  blinkled(ledblinkduration);
 }
 
 void webSocketEvent(AsyncWebSocket * server, AsyncWebSocketClient * client, AwsEventType type, void * arg, uint8_t *data, size_t len) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -204,6 +204,22 @@ void rpcWrapper() {
   serializeJson(jsonResponse,serJsonResponse);
 }
 
+void blinkled(int duration) {
+  if(led > 0) {
+    digitalWrite(led, LOW);
+    ledOffTime = millis() + duration;
+  }
+}
+
+void handleblinkled() {
+  if(led > 0) {
+    if (ledOffTime > 0 && millis() > ledOffTime) {
+	  digitalWrite(led, HIGH);
+	  ledOffTime = 0;
+	}
+  }
+}
+
 void GetDeviceInfo() {
   JsonDocument jsonResponse;
   jsonResponse["name"] = shelly_name;
@@ -219,6 +235,7 @@ void GetDeviceInfo() {
   jsonResponse["profile"] = "triphase";
   serializeJson(jsonResponse,serJsonResponse);
   DEBUG_SERIAL.println(serJsonResponse);
+  blinkled(50);
 }
 
 void EMGetStatus(){
@@ -247,6 +264,7 @@ void EMGetStatus(){
   jsonResponse["total_aprt_power"] = PhasePower[0].apparentPower + PhasePower[1].apparentPower + PhasePower[2].apparentPower;
   serializeJson(jsonResponse,serJsonResponse);
   DEBUG_SERIAL.println(serJsonResponse);
+  blinkled(50);
 }
 
 void EMDataGetStatus() {
@@ -262,6 +280,7 @@ void EMDataGetStatus() {
   jsonResponse["total_act_ret"] = PhaseEnergy[0].gridfeedin + PhaseEnergy[1].gridfeedin + PhaseEnergy[2].gridfeedin;
   serializeJson(jsonResponse,serJsonResponse);
   DEBUG_SERIAL.println(serJsonResponse);
+  blinkled(50);
 }
 
 void EMGetConfig() {
@@ -274,6 +293,7 @@ void EMGetConfig() {
   jsonResponse["ct_type"] = "120A";
   serializeJson(jsonResponse,serJsonResponse);
   DEBUG_SERIAL.println(serJsonResponse);
+  blinkled(50);
 }
 
 void webSocketEvent(AsyncWebSocket * server, AsyncWebSocketClient * client, AwsEventType type, void * arg, uint8_t *data, size_t len) {
@@ -736,18 +756,6 @@ void WifiManagerSetup() {
   DEBUG_SERIAL.println(WiFi.localIP());
 }
 
-void blinkled(int duration) {
-  digitalWrite(led, LOW);
-  ledOffTime = millis() + duration;
-}
-
-void handleblinkled() {
-  if (ledOffTime > 0 && millis() > ledOffTime) {
-    digitalWrite(led, HIGH);
-    ledOffTime = 0;
-  }
-}
-
 void setup(void) {
   DEBUG_SERIAL.begin(115200);
   WifiManagerSetup();
@@ -768,9 +776,6 @@ if(String(led_gpio).toInt() > 0) {
   server.on("/status", HTTP_GET, [](AsyncWebServerRequest *request) {
     EMGetStatus();
     request->send(200, "application/json", serJsonResponse);
-    if(led > 0) {
-      blinkled(50);
-    }
   });
 
   server.on("/reset", HTTP_GET, [](AsyncWebServerRequest *request) {
@@ -781,42 +786,27 @@ if(String(led_gpio).toInt() > 0) {
   server.on("/rpc/EM.GetStatus", HTTP_GET, [](AsyncWebServerRequest *request) {
     EMGetStatus();
     request->send(200, "application/json", serJsonResponse);
-    if(led > 0) {
-      blinkled(50);
-    }
   });
 
   server.on("/rpc/EMData.GetStatus", HTTP_GET, [](AsyncWebServerRequest *request) {
     EMDataGetStatus();
     request->send(200, "application/json", serJsonResponse);
-    if(led > 0) {
-      blinkled(50);
-    }
   });
 
   server.on("/rpc/EM.GetConfig", HTTP_GET, [](AsyncWebServerRequest *request) {
     EMGetConfig();
     request->send(200, "application/json", serJsonResponse);
-    if(led > 0) {
-      blinkled(50);
-    }
   });
 
   server.on("/rpc/Shelly.GetDeviceInfo", HTTP_GET, [](AsyncWebServerRequest *request) {
     GetDeviceInfo();
     request->send(200, "application/json", serJsonResponse);
-    if(led > 0) {
-      blinkled(50);
-    }
   });
 
   server.on("/rpc", HTTP_POST, [](AsyncWebServerRequest *request) {
     GetDeviceInfo();
     rpcWrapper();
     request->send(200, "application/json", serJsonResponse);
-    if(led > 0) {
-      blinkled(50);
-    }
   });
 
   webSocket.onEvent(webSocketEvent);
@@ -928,7 +918,5 @@ void loop() {
       startMillis = currentMillis;
     }
   }
-  if(led > 0) {
-    handleblinkled();
-  }
+  handleblinkled();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -743,8 +743,8 @@ void blinkLED(int duration) {
 
 void handleblinkLED() {
   if (ledOffTime > 0 && millis() > ledOffTime) {
-      digitalWrite(LED_PIN, HIGH);
-      ledOffTime = 0;
+    digitalWrite(LED_PIN, HIGH);
+    ledOffTime = 0;
   }
 }
 
@@ -765,7 +765,7 @@ void setup(void) {
     EMGetStatus();
     request->send(200, "application/json", serJsonResponse);
     #ifdef LED_PIN
-    blinkLED(50);
+      blinkLED(50);
     #endif
   });
 
@@ -778,7 +778,7 @@ void setup(void) {
     EMGetStatus();
     request->send(200, "application/json", serJsonResponse);
     #ifdef LED_PIN
-    blinkLED(50);
+      blinkLED(50);
     #endif
   });
 
@@ -786,7 +786,7 @@ void setup(void) {
     EMDataGetStatus();
     request->send(200, "application/json", serJsonResponse);
     #ifdef LED_PIN
-    blinkLED(50);
+      blinkLED(50);
     #endif
   });
 
@@ -794,7 +794,7 @@ void setup(void) {
     EMGetConfig();
     request->send(200, "application/json", serJsonResponse);
     #ifdef LED_PIN
-    blinkLED(50);
+      blinkLED(50);
     #endif
   });
 
@@ -802,7 +802,7 @@ void setup(void) {
     GetDeviceInfo();
     request->send(200, "application/json", serJsonResponse);
     #ifdef LED_PIN
-    blinkLED(50);
+      blinkLED(50);
     #endif
   });
 
@@ -811,7 +811,7 @@ void setup(void) {
     rpcWrapper();
     request->send(200, "application/json", serJsonResponse);
     #ifdef LED_PIN
-    blinkLED(50);
+      blinkLED(50);
     #endif
   });
 
@@ -925,6 +925,6 @@ void loop() {
     }
   }
   #ifdef LED_PIN
-  handleblinkLED();
+    handleblinkLED();
   #endif
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -718,7 +718,7 @@ void WifiManagerSetup() {
     preferences.putString("input_type", input_type);
     preferences.putString("mqtt_server", mqtt_server);
     preferences.putString("query_period", query_period);
-	preferences.putString("led_gpio", led_gpio);
+    preferences.putString("led_gpio", led_gpio);
     preferences.putString("shelly_mac", shelly_mac);
     preferences.putString("mqtt_port", mqtt_port);
     preferences.putString("mqtt_topic", mqtt_topic);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -753,8 +753,8 @@ void setup(void) {
   WifiManagerSetup();
 
   #ifdef LED_PIN
-  pinMode(LED_PIN, OUTPUT);
-  digitalWrite(LED_PIN, HIGH);
+    pinMode(LED_PIN, OUTPUT);
+    digitalWrite(LED_PIN, HIGH);
   #endif
 
   server.on("/", HTTP_GET, [](AsyncWebServerRequest *request) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,7 +46,7 @@ char query_period[10] = "1000";
 
 unsigned long ledOffTime = 0;
 int led = 0;
-int ledblinkduration = 50;
+const uint8_t ledblinkduration = 50;
 char led_gpio[2] = "";
 
 unsigned long period = 1000;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -214,9 +214,9 @@ void blinkled(int duration) {
 void handleblinkled() {
   if(led > 0) {
     if (ledOffTime > 0 && millis() > ledOffTime) {
-	  digitalWrite(led, HIGH);
-	  ledOffTime = 0;
-	}
+      digitalWrite(led, HIGH);
+      ledOffTime = 0;
+    }
   }
 }
 
@@ -764,9 +764,9 @@ if(String(led_gpio).toInt() > 0) {
   led = String(led_gpio).toInt();
 }
 
-  if(led > 0) {
-    pinMode(led, OUTPUT);
-    digitalWrite(led, HIGH);
+if(led > 0) {
+  pinMode(led, OUTPUT);
+  digitalWrite(led, HIGH);
 }
 
   server.on("/", HTTP_GET, [](AsyncWebServerRequest *request) {


### PR DESCRIPTION
The commit adds an optional feature to blink the internal LED on ESP32/ESP8266 when an HTTP request is received. 
The GPIO pin for the LED can be configured via the web interface.

![led](https://github.com/user-attachments/assets/ee70d006-faf2-4904-b828-ca0b02d43b8f)