### PR TITLE
parse Input from Tibber-Pulse adapter

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -23,49 +23,10 @@ lib_deps =
 	esp32async/ESPAsyncWebServer@^3.7.1
 	emelianov/modbus-esp8266@^4.1.0
 
-[lib_ESP8266]
-lib_deps = 
-	knolleary/PubSubClient@^2.8
-	bblanchon/ArduinoJson@^7.3.0
-	tzapu/WiFiManager@^2.0.17
-	vshymanskyy/Preferences@^2.1.0
-	esp32async/ESPAsyncWebServer@^3.7.1
-	emelianov/modbus-esp8266@^4.1.0
-
 [env:esp32-devkit-v1]
 platform = espressif32
 board = esp32doit-devkit-v1
 board_build.partitions = min_spiffs.csv
 framework = arduino
 lib_deps = ${lib_ESP32.lib_deps}
-monitor_speed = ${env.monitor_speed}
-
-[env:esp32-devkit-v4]
-platform = espressif32
-board = az-delivery-devkit-v4
-board_build.partitions = min_spiffs.csv
-framework = arduino
-lib_deps = ${lib_ESP32.lib_deps}
-monitor_speed = ${env.monitor_speed}
-
-[env:esp32-d1-mini]
-platform = espressif32
-board = wemos_d1_mini32
-board_build.partitions = min_spiffs.csv
-framework = arduino
-lib_deps = ${lib_ESP32.lib_deps}
-monitor_speed = ${env.monitor_speed}
-
-[env:esp8266]
-platform = espressif8266
-board = nodemcuv2
-framework = arduino
-lib_deps = ${lib_ESP8266.lib_deps}
-monitor_speed = ${env.monitor_speed}
-
-[env:esp8266-d1-mini]
-platform = espressif8266
-board = d1_mini
-framework = arduino
-lib_deps = ${lib_ESP8266.lib_deps}
 monitor_speed = ${env.monitor_speed}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 // Energy2Shelly_ESP v0.5.2
+// by Raibisch: add support for reading data from 'Tibber-Pulse' adapter
 #include <Arduino.h>
 #include <Preferences.h>
 #ifndef ESP32


### PR DESCRIPTION
I have created an extension to parse the 'Tibber-Pulse' adapter as input of energy values.

Tibber sells an 'Tibbe-Pulse' Adapter for there dynamic energy price contract. But it could be used without a Tibber contract. 
There is a description how to use Tibber-Pulse as local source for energy-metering:
[https://github.com/ProfDrYoMan/tibber_pulse_local_esphome](https://github.com/ProfDrYoMan/tibber_pulse_local_esphome
)
The 'charm' of this adapter is: there is no need to open the existing electrical installation. Only place the (magnetic) optical reader-adapter at the front of the meter.

SML-protocol description (in german): [https://www.schatenseite.de/2016/05/30/smart-message-language-stromzahler-auslesen](https://www.schatenseite.de/2016/05/30/smart-message-language-stromzahler-auslesen)

The code part for the SML parser is very generic (so it should work with other SML protocol based meters), but is only testet with my 'ISKRA MT631' meter.
I hope this code is useful for others.

All changed or added parts are marked with "by Raibisch" or "by JG" ...please remove this if you like to merge the pull request.

...a short remark to the code structure: 
first of all: the existing code work without problems. Thank you for your excellent work!

...but I'm not so happy with the existing code concept with parameter configuration via 'WifiManager'. Because I won't break the existing code structure, I added this pull request with the existing 'WifiManager' based configuration. In further versions I will isolate the shelly-em3 relevant code to an extra class-based lib. So it would be easier to integrate it in existing projects.
