### PR TITLE
Cleanup platformio.ini and add GH actions build (#1)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+    paths-ignore:
+      - '**.md'
+      - '/doc/**'
+      - '/screenshots/**'
+  pull_request:
+    branches: ["main"]
+    
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+
+      - name: Build demo
+        run: pio run

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,13 +9,11 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-core_dir = .platformio
 description = Firmware for ESP82xx/ESP32 for Shelly Emulator
 
 [env]
+framework = arduino
 monitor_speed = 115200
-
-[lib_ESP32]
 lib_deps = 
 	knolleary/PubSubClient@^2.8
 	bblanchon/ArduinoJson@^7.3.0
@@ -23,49 +21,13 @@ lib_deps =
 	esp32async/ESPAsyncWebServer@^3.7.1
 	emelianov/modbus-esp8266@^4.1.0
 
-[lib_ESP8266]
-lib_deps = 
-	knolleary/PubSubClient@^2.8
-	bblanchon/ArduinoJson@^7.3.0
-	tzapu/WiFiManager@^2.0.17
-	vshymanskyy/Preferences@^2.1.0
-	esp32async/ESPAsyncWebServer@^3.7.1
-	emelianov/modbus-esp8266@^4.1.0
-
-[env:esp32-devkit-v1]
+[env:esp32]
 platform = espressif32
-board = esp32doit-devkit-v1
+board = esp32dev
 board_build.partitions = min_spiffs.csv
-framework = arduino
-lib_deps = ${lib_ESP32.lib_deps}
-monitor_speed = ${env.monitor_speed}
-
-[env:esp32-devkit-v4]
-platform = espressif32
-board = az-delivery-devkit-v4
-board_build.partitions = min_spiffs.csv
-framework = arduino
-lib_deps = ${lib_ESP32.lib_deps}
-monitor_speed = ${env.monitor_speed}
-
-[env:esp32-d1-mini]
-platform = espressif32
-board = wemos_d1_mini32
-board_build.partitions = min_spiffs.csv
-framework = arduino
-lib_deps = ${lib_ESP32.lib_deps}
-monitor_speed = ${env.monitor_speed}
 
 [env:esp8266]
 platform = espressif8266
 board = nodemcuv2
-framework = arduino
-lib_deps = ${lib_ESP8266.lib_deps}
-monitor_speed = ${env.monitor_speed}
-
-[env:esp8266-d1-mini]
-platform = espressif8266
-board = d1_mini
-framework = arduino
-lib_deps = ${lib_ESP8266.lib_deps}
-monitor_speed = ${env.monitor_speed}
+lib_deps = ${env.lib_deps}
+	vshymanskyy/Preferences@^2.1.0


### PR DESCRIPTION
* Cleaned up the platformio.ini (there seems to be no need to build all the different boards, since no board specific code is used)
* Added github actions to verify the build (and as a second step later on add the possibility to create a webflash-page to install the firmware directly from the browsers)