### PR TITLE
Add web flashing page

### DIFF
--- a/.github/pages/index.html
+++ b/.github/pages/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Energy2Shelly Web Installer</title>
+	<meta charset="utf-8">
+	<script type="module" src="https://unpkg.com/esp-web-tools@9/dist/web/install-button.js?module"></script>
+</head>
+<body>
+    <h1>Energy2Shelly Web Installer</h1>
+
+    <p class="flashable">Make sure to close anything using your devices com port (e.g. Serial monitor). Just hit the button to install the firmware on your shelf.</p>
+	
+	<div id="webflash" style="display: none;" class="flashable">
+        <esp-web-install-button class="installButton" manifest="manifest.json">
+            <button slot="activate">Flash Firmware</button>
+        </esp-web-install-button>
+	</div>
+
+    <p id="notSupported" style="display: none; color: red;">
+        Your browser does not support the Web Serial API. Please open this page using Edge or Chrome.
+    </p>
+    
+
+    <script>
+        if(navigator.serial){
+            document.getElementById('webflash').style.display = 'block';
+        } else {
+			console.log('Serial not supported');
+            document.getElementById('notSupported').style.display = 'block';
+        }
+    </script>
+</body>
+</html>

--- a/.github/pages/manifest.json
+++ b/.github/pages/manifest.json
@@ -1,0 +1,19 @@
+{
+    "name": "Energy2Shelly",
+    "builds": [
+      {
+        "chipFamily": "ESP8266",
+        "improv": false,
+        "parts": [
+          { "path": "esp8266.bin", "offset": 0 }
+        ]
+      }
+      {
+        "chipFamily": "ESP32",
+        "improv": false,
+        "parts": [
+          { "path": "esp32.bin", "offset": 0 }
+        ]
+      }
+    ]
+  }

--- a/.github/pages/manifest.json
+++ b/.github/pages/manifest.json
@@ -7,7 +7,7 @@
         "parts": [
           { "path": "esp8266.bin", "offset": 0 }
         ]
-      }
+      },
       {
         "chipFamily": "ESP32",
         "improv": false,

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,30 @@ jobs:
           python-version: '3.13'
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio
-
-      - name: Build demo
+      - name: Build firmware
         run: pio run
+      - name: Copy firmware
+        run: |
+          cp .pio/build/esp32/firmware.bin ./.github/pages/esp32.bin
+          cp .pio/build/esp8266/firmware.bin ./.github/pages/esp8266.bin
+      - name: Setup Github Page
+        uses: actions/configure-pages@v5
+      - name: Upload webflash files
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./.github/pages/
+          
+  deploy:
+    needs: build
+    if: github.ref_name == 'main'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Merge ESP32 flash files
         run: |
           cd .pio/build/esp32
-          ~/.platformio/packages/tool-esptoolpy/esptool.py --chip esp32 merge_bin -o merged-flash.bin --flash_mode dio --flash_size 4MB 0x1000 bootloader.bin 0x8000 partitions.bin 0x10000 firmware.bin
+          python ~/.platformio/packages/tool-esptoolpy/esptool.py --chip esp32 merge_bin -o merged-flash.bin --flash_mode dio --flash_size 4MB 0x1000 bootloader.bin 0x8000 partitions.bin 0x10000 firmware.bin
       - name: Copy firmware
         run: |
           cp .pio/build/esp32/merged-flash.bin ./.github/pages/esp32.bin

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,9 +33,13 @@ jobs:
         run: pip install --upgrade platformio
       - name: Build firmware
         run: pio run
+      - name: Merge ESP32 flash files
+        run: |
+          cd .pio/build/esp32
+          ~/.platformio/packages/tool-esptoolpy/esptool.py --chip esp32 merge_bin -o merged-flash.bin --flash_mode dio --flash_size 4MB 0x1000 bootloader.bin 0x8000 partitions.bin 0x10000 firmware.bin
       - name: Copy firmware
         run: |
-          cp .pio/build/esp32/firmware.bin ./.github/pages/esp32.bin
+          cp .pio/build/esp32/merged-flash.bin ./.github/pages/esp32.bin
           cp .pio/build/esp8266/firmware.bin ./.github/pages/esp8266.bin
       - name: Setup Github Page
         uses: actions/configure-pages@v5


### PR DESCRIPTION
This adds a github pages deployment which allows flashing ESP8266 and ESP32 right from the browser.

This requires a small change in the github settings for this repo:
Settings => Pages => Source needs to be set to "GitHub Actions"