### PR TITLE
Improve Release/Deployment Process

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,8 +74,8 @@ jobs:
         with:
           fail_on_unmatched_files: true
           files: |
-            ./.github/pages/esp8266.bin
-            ./.github/pages/esp32.bin 
+            ./esp8266.bin
+            ./esp32.bin 
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
Improve the release and deployment process:
* Web Flash is no longer deployed from main-branch
* Draft a github-release and create a matching tag. Action will run and upload the artifacts into that release and deploy the web flasher with those files, so only the latest release will be in the web flash

This requires adjustments in the environments rules of the repo:
Under Settings => Environments => github-pages => "Deployment branches and tags" =>"Add deployment branch or tag rule" => Ref Type: Tag, Pattern: "v*"
Remove the "main" branch from the same menu, as it's no longer needed

<img width="1004" height="348" alt="image" src="https://github.com/user-attachments/assets/3c495419-6910-477b-8e7d-6b14195030ed" />
