### PR TITLE
Feature: Adds TibberPulse SML data source support and integrates it end-to-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ SMA Multicast code is based on https://www.mikrocontroller.net/topic/559607
 
 # Installation
 ## Option 1: Compile yourself
-1) compile and flash for your microcontroller using [PlatformIO](https://platformio.org/)
+Compile and flash for your microcontroller using [PlatformIO](https://platformio.org/)
 ## Option 2: Flash pre-compiled binary via browser 
-1) connect your ESP to your PC using USB and follow the instructions on the [webflasher](https://therealmoeder.github.io/Energy2Shelly_ESP/)
+Connect your ESP to your PC using USB and follow the instructions on the [webflasher](https://therealmoeder.github.io/Energy2Shelly_ESP/)
 
 # Configuration
-### 1. Power device and wait for a hotspot named "Energy2Shelly"
-### 2. Connect to that hotspot
-### 3. Enter wifi and configuration data using the captive portal or by opening http://192.168.4.1/
+#### 1. Power device and wait for a hotspot named "Energy2Shelly"
+#### 2. Connect to that hotspot
+#### 3. Enter wifi and configuration data using the captive portal or by opening http://192.168.4.1/
 
   #### On the captive portal you can currently set a data source for power data. The following options are available:
   - <code>MQTT</code>
@@ -77,8 +77,8 @@ SMA Multicast code is based on https://www.mikrocontroller.net/topic/559607
   
   The Shelly ID defaults to the ESP's MAC address, you may change this if you want to substitute an existing uni-meter configuration without reconnecting the battery to a new shelly device.
   
-### 4. Check if your device is visible in the WLAN. <code>http://IP-address</code><br>
-### 5. Check the current power data at <code>http://IP-address/status</code><br>
+#### 4. Check if your device is visible in the WLAN. <code>http://IP-address</code><br>
+#### 5. Check the current power data at <code>http://IP-address/status</code><br>
 - [ ] \(Optional) If you want to reset you Wifi-Configuration and/or reconfigure other settings go to <code>http://IP-address/reset</code> and reconnect to the Energy2Shelly hotspot.
 
 # Tested microcontrollers

--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ SMA Multicast code is based on https://www.mikrocontroller.net/topic/559607
     - you can setup host ip of Modbus device (e.g. Kostal Smart energy meter)
     - Modbus TCP port (usually 502)
     - Modbus Device ID of the unit ID (71 for KSEM)
+  - <code>TIBBERPULSE</code>
+    - parses SML data provided by your Tibber Pulse IR locally using [sml_parser](https://github.com/olliiiver/sml_parser) ESP library. This is a great option if you have a Tibber Pulse and want to use the data for zero feed-in with Hoymiles MS-A2, Growatt NOAH/NEXA or Marstek Venus inverters/batteries.
+    - follow [these](https://github.com/marq24/ha-tibber-pulse-local#tibber-pulse-ir-local) instructions to access
+      the data of your Tibber Pulse / Bridge locally
+    - provide the IP address and port of the Websocket API, device admin and password of your Tibber Bridge in the configuration options to allow Energy2Shelly_ESP to connect to the Websocket API and receive power data
+    - the parser will automatically extract total power, phase power and energy from/to grid data from the Websocket API data stream and make it available for the Shelly Pro 3EM Emulator.
+    - support for following power meters is implemented and tested:
+      - EMH EHZB (SML message length 248)
+      - eBZ DD3 (SML message length 396)
+    - support for your power meter can be added, if you provide the SML message length of your meter and confirm that the parser works with your meter's data stream, please open an issue or even better a PR with the details!
 
   ### Here are some sample generic HTTP query paths for common devices:
   - Fronius: <code>http://IP-address/solar_api/v1/GetMeterRealtimeData.cgi?Scope=System</code>

--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ Connect your ESP to your PC using USB and follow the instructions on the [webfla
   - <code>TIBBERPULSE</code>
     - Parses SML data from your Tibber Pulse IR locally using the [sml_parser](https://github.com/olliiiver/sml_parser) ESP library. This is a great option if you want to use Tibber Pulse data for zero feed-in with Hoymiles MS-A2, Growatt NOAH/NEXA, or Marstek Venus inverters/batteries.
     - Follow [these](https://github.com/marq24/ha-tibber-pulse-local#tibber-pulse-ir-local) instructions to access your Tibber Pulse/Bridge data locally.
-    - Provide the IP address and port of the WebSocket API, plus username and password of your Tibber Bridge, in the configuration options so Energy2Shelly_ESP can connect and receive power data.
-    - The parser automatically extracts total power, phase power, and energy from/to the grid from the WebSocket API data stream and makes it available for the Shelly Pro 3EM Emulator.
+    - Provide the `IP address / hostname` and `port` of the WebSocket API, plus `username` and `password` of your Tibber Bridge, in the configuration options so Energy2Shelly_ESP can connect and receive power data.
+    - The parser automatically extracts `total power`, `phase power` and `energy from/to the grid` from the WebSocket API data stream and makes it available for the Shelly Pro 3EM Emulator.
     - Following power meters are currently supported and implemented in the parser:
-      - EMH EHZB (SML message length: 248)
-      - eBZ DD3 (SML message length: 396)
-    - Support for additional power meters can be added. If you can provide your meter's SML sample data and message length and confirm that the parser works with your meter's data stream, then please open an issue or, even better, a PR with the details!
+      - **EMH EHZB** (SML message length: 248)
+      - **eBZ DD3** (SML message length: 396)
+    - Support for additional power meters can be easily added. If you can provide your meter's SML sample data and message length and confirm that the parser works with your meter's data stream, then please open an issue or, even better, a PR with the details!
 
   #### Here are some sample generic HTTP query paths for common devices:
   - Fronius: <code>http://IP-address/solar_api/v1/GetMeterRealtimeData.cgi?Scope=System</code>

--- a/README.md
+++ b/README.md
@@ -61,15 +61,14 @@ SMA Multicast code is based on https://www.mikrocontroller.net/topic/559607
     - Modbus TCP port (usually 502)
     - Modbus Device ID of the unit ID (71 for KSEM)
   - <code>TIBBERPULSE</code>
-    - parses SML data provided by your Tibber Pulse IR locally using [sml_parser](https://github.com/olliiiver/sml_parser) ESP library. This is a great option if you have a Tibber Pulse and want to use the data for zero feed-in with Hoymiles MS-A2, Growatt NOAH/NEXA or Marstek Venus inverters/batteries.
-    - follow [these](https://github.com/marq24/ha-tibber-pulse-local#tibber-pulse-ir-local) instructions to access
-      the data of your Tibber Pulse / Bridge locally
-    - provide the IP address and port of the Websocket API, device admin and password of your Tibber Bridge in the configuration options to allow Energy2Shelly_ESP to connect to the Websocket API and receive power data
-    - the parser will automatically extract total power, phase power and energy from/to grid data from the Websocket API data stream and make it available for the Shelly Pro 3EM Emulator.
-    - support for following power meters is implemented and tested:
-      - EMH EHZB (SML message length 248)
-      - eBZ DD3 (SML message length 396)
-    - support for your power meter can be added, if you provide the SML message length of your meter and confirm that the parser works with your meter's data stream, please open an issue or even better a PR with the details!
+    - Parses SML data from your Tibber Pulse IR locally using the [sml_parser](https://github.com/olliiiver/sml_parser) ESP library. This is a great option if you want to use Tibber Pulse data for zero feed-in with Hoymiles MS-A2, Growatt NOAH/NEXA, or Marstek Venus inverters/batteries.
+    - Follow [these](https://github.com/marq24/ha-tibber-pulse-local#tibber-pulse-ir-local) instructions to access your Tibber Pulse/Bridge data locally.
+    - Provide the IP address and port of the WebSocket API, plus username and password of your Tibber Bridge, in the configuration options so Energy2Shelly_ESP can connect and receive power data.
+    - The parser automatically extracts total power, phase power, and energy from/to the grid from the WebSocket API data stream and makes it available for the Shelly Pro 3EM Emulator.
+    - Following power meters are currently supported and implemented in the parser:
+      - EMH EHZB (SML message length: 248)
+      - eBZ DD3 (SML message length: 396)
+    - Support for additional power meters can be added. If you can provide your meter's SML sample data and message length and confirm that the parser works with your meter's data stream, then please open an issue or, even better, a PR with the details!
 
   ### Here are some sample generic HTTP query paths for common devices:
   - Fronius: <code>http://IP-address/solar_api/v1/GetMeterRealtimeData.cgi?Scope=System</code>

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ SMA Multicast code is based on https://www.mikrocontroller.net/topic/559607
 1) connect your ESP to your PC using USB and follow the instructions on the [webflasher](https://therealmoeder.github.io/Energy2Shelly_ESP/)
 
 # Configuration
-1) Power device and wait for a hotspot named "Energy2Shelly"
-2) Connect to that hotspot
-3) Enter wifi and configuration data using the captive portal or by opening http://192.168.4.1/
+## 1. Power device and wait for a hotspot named "Energy2Shelly"
+## 2. Connect to that hotspot
+## 3. Enter wifi and configuration data using the captive portal or by opening http://192.168.4.1/
 
   ### On the captive portal you can currently set a data source for power data. The following options are available:
   - <code>MQTT</code>
@@ -77,8 +77,8 @@ SMA Multicast code is based on https://www.mikrocontroller.net/topic/559607
   
   The Shelly ID defaults to the ESP's MAC address, you may change this if you want to substitute an existing uni-meter configuration without reconnecting the battery to a new shelly device.
   
-4) Check if your device is visible in the WLAN. <code>http://IP-address</code><br>
-5) Check the current power data at <code>http://IP-address/status</code><br>
+## 4. Check if your device is visible in the WLAN. <code>http://IP-address</code><br>
+## 5. Check the current power data at <code>http://IP-address/status</code><br>
 - [ ] \(Optional) If you want to reset you Wifi-Configuration and/or reconfigure other settings go to <code>http://IP-address/reset</code> and reconnect to the Energy2Shelly hotspot.
 
 # Tested microcontrollers

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ SMA Multicast code is based on https://www.mikrocontroller.net/topic/559607
 1) connect your ESP to your PC using USB and follow the instructions on the [webflasher](https://therealmoeder.github.io/Energy2Shelly_ESP/)
 
 # Configuration
-## 1. Power device and wait for a hotspot named "Energy2Shelly"
-## 2. Connect to that hotspot
-## 3. Enter wifi and configuration data using the captive portal or by opening http://192.168.4.1/
+### 1. Power device and wait for a hotspot named "Energy2Shelly"
+### 2. Connect to that hotspot
+### 3. Enter wifi and configuration data using the captive portal or by opening http://192.168.4.1/
 
-  ### On the captive portal you can currently set a data source for power data. The following options are available:
+  #### On the captive portal you can currently set a data source for power data. The following options are available:
   - <code>MQTT</code>
     - Server IP, port, username, password and topic
     - Power values on the MQTT topic are expected in JSON format. The are multiple fields to define available values using a JSON Path-style syntax.
@@ -70,15 +70,15 @@ SMA Multicast code is based on https://www.mikrocontroller.net/topic/559607
       - eBZ DD3 (SML message length: 396)
     - Support for additional power meters can be added. If you can provide your meter's SML sample data and message length and confirm that the parser works with your meter's data stream, then please open an issue or, even better, a PR with the details!
 
-  ### Here are some sample generic HTTP query paths for common devices:
+  #### Here are some sample generic HTTP query paths for common devices:
   - Fronius: <code>http://IP-address/solar_api/v1/GetMeterRealtimeData.cgi?Scope=System</code>
   - Tasmota devices: <code>http://IP-address/cm?cmnd=status%2010</code>
   - ioBroker datapoints: <code>http://IP-address:8082/getBulk/smartmeter.0.1-0:1_8_0__255.value,smartmeter.0.1-0:2_8_0__255.value,smartmeter.0.1-0:16_7_0__255.value/?json</code>
   
   The Shelly ID defaults to the ESP's MAC address, you may change this if you want to substitute an existing uni-meter configuration without reconnecting the battery to a new shelly device.
   
-## 4. Check if your device is visible in the WLAN. <code>http://IP-address</code><br>
-## 5. Check the current power data at <code>http://IP-address/status</code><br>
+### 4. Check if your device is visible in the WLAN. <code>http://IP-address</code><br>
+### 5. Check the current power data at <code>http://IP-address/status</code><br>
 - [ ] \(Optional) If you want to reset you Wifi-Configuration and/or reconfigure other settings go to <code>http://IP-address/reset</code> and reconnect to the Energy2Shelly hotspot.
 
 # Tested microcontrollers

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,6 +20,7 @@ lib_deps =
 	tzapu/WiFiManager@^2.0.17
 	esp32async/ESPAsyncWebServer@^3.10.2
 	emelianov/modbus-esp8266@^4.1.0
+	olliiiver/SML Parser@^0.29
 
 [env:esp32]
 platform = espressif32

--- a/src/config/Configuration.cpp
+++ b/src/config/Configuration.cpp
@@ -179,8 +179,8 @@ void WifiManagerSetup() {
 
   const char *show_pwd_str = "<input type=\"checkbox\" onclick=\"t('%s')\">&nbsp;<label>Show password</label><br/>";
 
-  WiFiManagerParameter custom_section1("<h3>General settings</h3>");
-  WiFiManagerParameter custom_input_type("type", "<b>Data source</b><br><code>MQTT</code> for MQTT<br><code>HTTP</code> for generic HTTP<br><code>SMA</code> for SMA EM/HM multicast<br><code>SHRDZM</code> for SHRDZM UDP data<br><code>SUNSPEC</code> for Modbus TCP SUNSPEC data", input_type, 40);
+  WiFiManagerParameter custom_section1("<h3>General settings</h3><script>function t(s) { var x = document.getElementById(s); x.type === \"password\" ? x.type = \"text\" : x.type = \"password\"; }</script>");
+  WiFiManagerParameter custom_input_type("type", "<b>Data source</b><br><code>MQTT</code> for MQTT<br><code>HTTP</code> for generic HTTP<br><code>SMA</code> for SMA EM/HM multicast<br><code>SHRDZM</code> for SHRDZM UDP data<br><code>SUNSPEC</code> for Modbus TCP SUNSPEC data<br><code>TIBBERPULSE</code> for TibberPulse SML data", input_type, 40);
   WiFiManagerParameter custom_mqtt_server("server", "<b>Server</b><br>MQTT Server IP, query url for generic HTTP or Modbus TCP server IP for SUNSPEC", mqtt_server, 160);
   WiFiManagerParameter custom_mqtt_port("port", "<b>Port</b><br> for MQTT or Modbus TCP (SUNSPEC)", mqtt_port, 6);
   WiFiManagerParameter param_ntp_server("ntp_server", "NTP server <span title=\"for time synchronization\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", ntp_server, 40);

--- a/src/config/Configuration.cpp
+++ b/src/config/Configuration.cpp
@@ -43,6 +43,12 @@ char force_pwr_decimals[6] = "true"; // to fix Marstek bug
 bool forcePwrDecimals = true; // to fix Marstek bug
 char sma_id[17] = "";
 
+// Tibber related
+char tibber_url[41] = "x.x.x.x[:xxxx]"; // IP of TibberPulse
+char tibber_user[6] = "admin";         // fixed user
+char tibber_password[10] = "xxxx-xxxx"; // replace with password printed on Tibbel-Pulse-Adapter
+char tibber_rpc[21] = "/data.json?node_id=1"; // fixed rpc path
+
 // LED settings
 char led_gpio[3] = "";
 char led_gpio_i[6];
@@ -80,6 +86,7 @@ bool dataSMA = false;
 bool dataSHRDZM = false;
 bool dataHTTP = false;
 bool dataSUNSPEC = false;
+bool dataTIBBERPULSE = false;
 
 Preferences preferences;
 
@@ -165,7 +172,13 @@ void WifiManagerSetup() {
   strcpy(shelly_port, preferences.getString("shelly_port", shelly_port).c_str());
   strcpy(force_pwr_decimals, preferences.getString("force_pwr_decimals", force_pwr_decimals).c_str());
   strcpy(sma_id, preferences.getString("sma_id", sma_id).c_str());
-  
+  // TibberPulse settings
+  strcpy(tibber_url, preferences.getString("tibber_url", tibber_url).c_str());
+  strcpy(tibber_user, preferences.getString("tibber_user", tibber_user).c_str());
+  strcpy(tibber_password, preferences.getString("tibber_password", tibber_password).c_str());
+
+  const char *show_pwd_str = "<input type=\"checkbox\" onclick=\"t('%s')\">&nbsp;<label>Show password</label><br/>";
+
   WiFiManagerParameter custom_section1("<h3>General settings</h3>");
   WiFiManagerParameter custom_input_type("type", "<b>Data source</b><br><code>MQTT</code> for MQTT<br><code>HTTP</code> for generic HTTP<br><code>SMA</code> for SMA EM/HM multicast<br><code>SHRDZM</code> for SHRDZM UDP data<br><code>SUNSPEC</code> for Modbus TCP SUNSPEC data", input_type, 40);
   WiFiManagerParameter custom_mqtt_server("server", "<b>Server</b><br>MQTT Server IP, query url for generic HTTP or Modbus TCP server IP for SUNSPEC", mqtt_server, 160);
@@ -193,6 +206,14 @@ void WifiManagerSetup() {
   WiFiManagerParameter custom_power_l3_path("power_l3_path", "<b>Phase 3 power JSON path</b><br>Phase 3 power JSON path<br>optional", power_l3_path, 60);
   WiFiManagerParameter custom_energy_in_path("energy_in_path", "<b>Energy from grid JSON path</b><br>e.g. <code>ENERGY.Grid</code>", energy_in_path, 60);
   WiFiManagerParameter custom_energy_out_path("energy_out_path", "<b>Energy to grid JSON path</b><br>e.g. <code>ENERGY.FeedIn</code>", energy_out_path, 60);
+  // TibberPulse section
+  WiFiManagerParameter param_section_tibberpulse("<hr><h3>TibberPulse options</h3>");
+  WiFiManagerParameter param_tibber_url("tibber_url", "Hostname/IP[:port] <span title=\"e.g.: 192.168.0.1:8080\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", tibber_url, 40);
+  WiFiManagerParameter param_tibber_user("tibber_user", "User <span title=\"defaults to: admin\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", tibber_user, 5);
+  WiFiManagerParameter param_tibber_password("tibber_password", "Password <span title=\"as printed on bridge device: xxxx-xxxx\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", tibber_password, 9, "type='password'");
+  char buf_tibber_pwd_show_pwd[150];
+  sprintf(buf_tibber_pwd_show_pwd, show_pwd_str, "tibber_password");
+  WiFiManagerParameter param_tibber_password_show_password(buf_tibber_pwd_show_pwd);
 
   WiFiManager wifiManager;
   if (!DEBUG) {
@@ -229,7 +250,12 @@ void WifiManagerSetup() {
   wifiManager.addParameter(&custom_power_l3_path);
   wifiManager.addParameter(&custom_energy_in_path);
   wifiManager.addParameter(&custom_energy_out_path);
-  
+  // TibberPulse section
+  wifiManager.addParameter(&param_section_tibberpulse);
+  wifiManager.addParameter(&param_tibber_url);
+  wifiManager.addParameter(&param_tibber_user);
+  wifiManager.addParameter(&param_tibber_password);
+  wifiManager.addParameter(&param_tibber_password_show_password);
 
   if (!wifiManager.autoConnect("Energy2Shelly")) {
     DEBUG_SERIAL.println("failed to connect and hit timeout");
@@ -263,6 +289,10 @@ void WifiManagerSetup() {
   strcpy(shelly_port, custom_shelly_port.getValue());
   strcpy(force_pwr_decimals, custom_force_pwr_decimals.getValue());
   strcpy(sma_id, custom_sma_id.getValue());
+  // TibberPulse
+  strcpy(tibber_url, param_tibber_url.getValue());
+  strcpy(tibber_user, param_tibber_user.getValue());
+  strcpy(tibber_password, param_tibber_password.getValue());
 
   DEBUG_SERIAL.println("The values in the preferences are: ");
   DEBUG_SERIAL.println("\tinput_type : " + String(input_type));
@@ -288,6 +318,10 @@ void WifiManagerSetup() {
   DEBUG_SERIAL.println("\tshelly_port : " + String(shelly_port));
   DEBUG_SERIAL.println("\tforce_pwr_decimals : " + String(force_pwr_decimals));
   DEBUG_SERIAL.println("\tsma_id : " + String(sma_id));
+  DEBUG_SERIAL.println("\tTibberPulse options:");
+  DEBUG_SERIAL.println("\t - tibber_url: " + String(tibber_url));
+  DEBUG_SERIAL.println("\t - tibber_user: " + String(tibber_user));
+  DEBUG_SERIAL.println("\t - tibber_password: ********");
 
   if (strcmp(input_type, "SMA") == 0) {
     dataSMA = true;
@@ -301,8 +335,10 @@ void WifiManagerSetup() {
   } else if (strcmp(input_type, "SUNSPEC") == 0) {
     dataSUNSPEC = true;
     DEBUG_SERIAL.println("Enabling SUNSPEC data input");
-  }
-  else {
+  } else if (strcmp(input_type, "TIBBERPULSE") == 0) {
+    dataTIBBERPULSE = true;
+    DEBUG_SERIAL.println("Enabling TIBBERPULSE data input");
+  } else {
     dataMQTT = true;
     DEBUG_SERIAL.println("Enabling MQTT data input");
   }
@@ -344,6 +380,9 @@ void WifiManagerSetup() {
     preferences.putString("shelly_port", shelly_port);
     preferences.putString("force_pwr_decimals", force_pwr_decimals);
     preferences.putString("sma_id", sma_id);
+    preferences.putString("tibber_url", tibber_url);
+    preferences.putString("tibber_user", tibber_user);
+    preferences.putString("tibber_password", tibber_password);
     wifiManager.reboot();
   }
   DEBUG_SERIAL.println("local ip");

--- a/src/config/Configuration.h
+++ b/src/config/Configuration.h
@@ -80,6 +80,11 @@ extern char force_pwr_decimals[6];
 extern bool forcePwrDecimals;
 extern char sma_id[17];
 
+extern char tibber_url[41];
+extern char tibber_user[6];
+extern char tibber_password[10];
+extern char tibber_rpc[21];
+
 // LED settings
 extern char led_gpio[3];
 extern char led_gpio_i[6];
@@ -117,6 +122,7 @@ extern bool dataSMA;
 extern bool dataSHRDZM;
 extern bool dataHTTP;
 extern bool dataSUNSPEC;
+extern bool dataTIBBERPULSE;
 
 extern Preferences preferences;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -239,11 +239,16 @@ void loop() {
       parseSUNSPEC();
       startMillis = currentMillis;
     }
-   
   }
   if (dataHTTP) {
     if (currentMillis - startMillis >= period) {
       queryHTTP();
+      startMillis = currentMillis;
+    }
+  }
+  if (dataTIBBERPULSE) {
+    if (currentMillis - startMillis >= period) {
+      parseTibberPulse();
       startMillis = currentMillis;
     }
   }

--- a/src/parsers/Parsers.h
+++ b/src/parsers/Parsers.h
@@ -9,5 +9,6 @@ void mqtt_reconnect();
 void parseSHRDZM();
 void parseSMA();
 void parseSUNSPEC();
+void parseTibberPulse();
 
 #endif // PARSERS_H

--- a/src/parsers/TibberPulseParser.cpp
+++ b/src/parsers/TibberPulseParser.cpp
@@ -1,0 +1,113 @@
+#include "../config/Configuration.h"
+#include "../data/DataProcessing.h"
+#include <sml.h>
+
+// functions for TibberPulse
+double tibber_consumption = 0, tibber_production = 0, tibber_power = 0;
+
+typedef struct {
+  const unsigned char OBIS[6];
+  void (*Handler)();
+} OBISHandler;
+
+// supports currently only:
+// - consumption (OBIS 1-0:1.8.0)
+// - production  (OBIS 1-0:2.8.0)
+// - power       (OBIS 1-0:16.7.0)
+// this could be extended later if needed for other OBIS codes (at least those used in TibberPulse SML)
+void Consumption() { smlOBISWh(tibber_consumption); }
+void Production() { smlOBISWh(tibber_production); }
+void Power() { smlOBISW(tibber_power); }
+
+OBISHandler OBISHandlers[] = {
+  {{0x01, 0x00, 0x01, 0x08, 0x00, 0xff}, &Consumption}, /* 1-0: 1. 8.0*255 (Consumption Total) */
+  {{0x01, 0x00, 0x02, 0x08, 0x00, 0xff}, &Production},  /* 1-0: 2. 8.0*255 (Production Total) */
+  {{0x01, 0x00, 0x10, 0x07, 0x00, 0xff}, &Power},       /* 1-0:16. 7.0*255 (power) */
+  {{0, 0}}
+};
+
+// SML message length tested with following power meters:
+enum {
+  // EMH eHZB
+  SML_PM_EMH_EHZB = 248,
+  // eBZ DD3
+  SML_PM_EBZ_DD3 = 396,
+  SMLPAYLOADMAXSIZE = 500
+};
+byte smlpayload[SMLPAYLOADMAXSIZE]{0};
+
+bool parseTibberPulse() {
+  bool ret = true;
+  int getlength = 0;
+  DEBUG_SERIAL.print("Querying TibberPulse raw SML: ");
+  String url = "http://";
+  url += String(tibber_url);
+  url += String(tibber_rpc);
+  DEBUG_SERIAL.printf("URL:%s, user:%s\r\n", url.c_str(), tibber_user);
+  http.begin(wifi_client, url);
+  http.setAuthorization(tibber_user, tibber_password);
+  int httpResponseCode = http.GET();
+  if (httpResponseCode > 0) {
+    getlength = http.getSize();
+    DEBUG_SERIAL.printf("Response message size=%d\r\n", getlength);
+    if ((getlength > SMLPAYLOADMAXSIZE) || (getlength == 0)) {
+      http.end();
+      return false;
+    }
+    WiFiClient *w = http.getStreamPtr();
+    w->readBytes(smlpayload, getlength);
+    // the OBIS codes for consumption (1-0:1.8.0*255) and power (1-0:16.7.0*255) are the same,
+    // the SML message length might be different, but reading these should still work
+    if (getlength != SML_PM_EMH_EHZB && getlength != SML_PM_EBZ_DD3) {
+      DEBUG_SERIAL.printf("ERROR: SML data not in expected length! length=%d \r\n", getlength);
+      // for extra debugging
+      for (int i = 0; i < getlength; i++) {
+          DEBUG_SERIAL.printf("%02xh ", smlpayload[i]);
+      }
+      DEBUG_SERIAL.println();
+      ret = false;
+    } else {
+      int i = 0, iHandler = 0;
+      unsigned char c;
+      sml_states_t s;
+      for (i = 0; i < getlength; ++i) {
+        c = smlpayload[i];
+        s = smlState(c);
+        switch (s) {
+        case SML_START:
+          /* reset local vars */
+          tibber_consumption = 0;
+          tibber_production = 0;
+          tibber_power = 0;
+          break;
+        case SML_LISTEND:
+          for (
+            iHandler = 0;
+            OBISHandlers[iHandler].Handler != 0 && !(smlOBISCheck(OBISHandlers[iHandler].OBIS));
+            iHandler++
+          );
+          if (OBISHandlers[iHandler].Handler != 0) {
+            OBISHandlers[iHandler].Handler();
+          }
+          break;
+        case SML_UNEXPECTED:
+          DEBUG_SERIAL.printf(">>> Unexpected byte >%02X<! <<<\n", smlpayload[i]);
+          break;
+        case SML_FINAL:
+          setEnergyData(tibber_consumption, tibber_production); // input and output energy from TibberPulse
+          setPowerData(tibber_power);
+          ret = true;
+          break;
+        default:
+          break;
+        }
+      }
+    }
+  } else {
+      DEBUG_SERIAL.printf("HTTP request failed, error code: %d\n", httpResponseCode);
+      ret = false;
+  }
+  // Free resources
+  http.end();
+  return ret;
+}


### PR DESCRIPTION
This PR adds TibberPulse as a new input data source for Energy2Shelly_ESP and solves #52. 

It introduces a dedicated TibberPulse parser, wires it into the main polling loop, extends configuration and persistence with Tibber-specific settings, adds the required SML parser dependency, and updates documentation with setup details and supported meters.
### What Changed
- Added TibberPulse parser implementation in [TibberPulseParser.cpp](https://github.com/oldboys92/Energy2Shelly_ESP/blob/feature_tibber-pulse/src/parsers/TibberPulseParser.cpp).
- Added TibberPulse parser declaration in [Parsers.h](https://github.com/oldboys92/Energy2Shelly_ESP/blob/feature_tibber-pulse/src/parsers/Parsers.h).
- Integrated TibberPulse polling into runtime loop in [main.cpp](https://github.com/oldboys92/Energy2Shelly_ESP/blob/feature_tibber-pulse/src/main.cpp).
- Added Tibber configuration fields and datasource flag in [Configuration.h](https://github.com/oldboys92/Energy2Shelly_ESP/blob/feature_tibber-pulse/src/config/Configuration.h).
- Extended WiFiManager setup and preferences storage/loading for Tibber settings in [Configuration.cpp](https://github.com/oldboys92/Energy2Shelly_ESP/blob/feature_tibber-pulse/src/config/Configuration.cpp).
- Added SML Parser library dependency in [platformio.ini](https://github.com/oldboys92/Energy2Shelly_ESP/blob/feature_tibber-pulse/platformio.ini).
- Updated user documentation with TibberPulse configuration and parser support details in [README.md](https://github.com/oldboys92/Energy2Shelly_ESP/blob/feature_tibber-pulse/README.md).
### Implementation Notes
- TibberPulse mode performs authenticated HTTP requests to fetch raw SML payload data.
Parsing currently targets OBIS values for `total import energy`, `total export energy`, and `active power`.
- Current validation supports known SML message lengths for:
  - **EMH EHZB** (248)
  - **eBZ DD3** (396)
- Configuration now includes Tibber `host/IP:port`, `username`, and `password` fields in captive portal.
Tibber Pulse device `password` is masked in debug output logs.
### Testing
- Build verification completed successfully:
  - `platformio run (exit code 0)`
### Compatibility / Risk
- No breaking API changes expected for existing MQTT/SMA/SHRDZM/HTTP/SUNSPEC flows.
- Tibber parsing is currently constrained to supported message-length profiles; unsupported meters are expected to fail validation until extended.
### Checklist
- Added feature implementation
- Wired feature into runtime flow
- Added dependency
- Updated configuration and persistence
- Updated documentation
- Verified successful build