### PR TITLE
Remove legacy forced power-decimal workaround

### DIFF
--- a/src/config/Configuration.cpp
+++ b/src/config/Configuration.cpp
@@ -41,8 +41,6 @@ char shelly_port[6] = "2220"; // old: 1010; new (FW>=226): 2220; Venus A and E 3
 // Query and protocol settings
 char query_period[10] = "1000";
 char modbus_dev[10] = "71"; // default for KSEM
-char force_pwr_decimals[6] = "true"; // to fix Marstek bug
-bool forcePwrDecimals = true; // to fix Marstek bug
 char sma_id[17] = "";
 
 // LED settings
@@ -167,7 +165,6 @@ void WifiManagerSetup() {
   strcpy(energy_in_path, preferences.getString("energy_in_path", energy_in_path).c_str());
   strcpy(energy_out_path, preferences.getString("energy_out_path", energy_out_path).c_str());
   strcpy(shelly_port, preferences.getString("shelly_port", shelly_port).c_str());
-  strcpy(force_pwr_decimals, preferences.getString("force_pwr_decimals", force_pwr_decimals).c_str());
   strcpy(sma_id, preferences.getString("sma_id", sma_id).c_str());
 
   const char *show_pwd_str = "<input type=\"checkbox\" onclick=\"t('%s')\">&nbsp;<label>Show Password</label><br/>";
@@ -188,7 +185,6 @@ void WifiManagerSetup() {
   WiFiManagerParameter custom_led_gpio_i("led_gpio_i", "<b>GPIO is inverted</b><br><code>true</code> or <code>false</code>", led_gpio_i, 6);
   WiFiManagerParameter custom_shelly_mac("mac", "<b>Shelly ID</b><br>12 char hexadecimal, defaults to MAC address of ESP", shelly_mac, 13);
   WiFiManagerParameter custom_shelly_port("shelly_port", "<b>Shelly UDP port</b><br><code>1010</code> or <code>2220</code> depending on Marstek Venus model and firmware version", shelly_port, 6);
-  WiFiManagerParameter custom_force_pwr_decimals("force_pwr_decimals", "<b>Force decimals numbers for Power values</b><br><code>true</code> to fix Marstek bug", force_pwr_decimals, 6);
   WiFiManagerParameter custom_sma_id("sma_id", "<b>SMA serial number</b><br>optional serial number if you have more than one SMA EM/HM in your network", sma_id, 16);
   WiFiManagerParameter custom_section2("<hr><h3>MQTT options</h3>");
   WiFiManagerParameter custom_mqtt_topic("topic", "<b>MQTT Topic</b>", mqtt_topic, 90);
@@ -229,7 +225,6 @@ void WifiManagerSetup() {
   wifiManager.addParameter(&custom_led_gpio_i);
   wifiManager.addParameter(&custom_shelly_mac);
   wifiManager.addParameter(&custom_shelly_port);
-  wifiManager.addParameter(&custom_force_pwr_decimals);
   wifiManager.addParameter(&custom_sma_id);
   wifiManager.addParameter(&custom_section2);
   wifiManager.addParameter(&custom_mqtt_port);
@@ -281,7 +276,6 @@ void WifiManagerSetup() {
   strcpy(energy_in_path, custom_energy_in_path.getValue());
   strcpy(energy_out_path, custom_energy_out_path.getValue());
   strcpy(shelly_port, custom_shelly_port.getValue());
-  strcpy(force_pwr_decimals, custom_force_pwr_decimals.getValue());
   strcpy(sma_id, custom_sma_id.getValue());
 
   DEBUG_SERIAL.println("The values in the preferences are: ");
@@ -308,7 +302,6 @@ void WifiManagerSetup() {
   DEBUG_SERIAL.println("\tenergy_in_path : " + String(energy_in_path));
   DEBUG_SERIAL.println("\tenergy_out_path : " + String(energy_out_path));
   DEBUG_SERIAL.println("\tshelly_port : " + String(shelly_port));
-  DEBUG_SERIAL.println("\tforce_pwr_decimals : " + String(force_pwr_decimals));
   DEBUG_SERIAL.println("\tsma_id : " + String(sma_id));
   if (strcmp(input_type, "SMA") == 0) {
     dataSMA = true;
@@ -331,12 +324,6 @@ void WifiManagerSetup() {
     led_i = true;
   } else {
     led_i = false;
-  }
-
-  if (strcmp(force_pwr_decimals, "true") == 0) {
-    forcePwrDecimals = true;
-  } else {
-    forcePwrDecimals = false;
   }
 
   if (shouldSaveConfig) {
@@ -364,7 +351,6 @@ void WifiManagerSetup() {
     preferences.putString("energy_in_path", energy_in_path);
     preferences.putString("energy_out_path", energy_out_path);
     preferences.putString("shelly_port", shelly_port);
-    preferences.putString("force_pwr_decimals", force_pwr_decimals);
     preferences.putString("sma_id", sma_id);
     wifiManager.reboot();
   }

--- a/src/config/Configuration.h
+++ b/src/config/Configuration.h
@@ -78,8 +78,6 @@ extern char shelly_port[6];
 // Query and protocol settings
 extern char query_period[10];
 extern char modbus_dev[10];
-extern char force_pwr_decimals[6];
-extern bool forcePwrDecimals;
 extern char sma_id[17];
 
 // LED settings

--- a/src/data/DataProcessing.cpp
+++ b/src/data/DataProcessing.cpp
@@ -8,12 +8,7 @@ EnergyData PhaseEnergy[3];
 String serJsonResponse;
 
 double round2(double value) {
-  int ivalue = (int) round(value * 100.0);
-
-  // fix Marstek bug: make sure to have decimal numbers
-  if(forcePwrDecimals && (ivalue % 100 == 0)) ivalue++;
-
-  return ivalue / 100.0;
+  return round(value * 100.0) / 100.0;
 }
 
 bool isValidIPAddress(const char* ipString) {

--- a/src/data/DataProcessing.cpp
+++ b/src/data/DataProcessing.cpp
@@ -8,11 +8,11 @@ EnergyData PhaseEnergy[3];
 String serJsonResponse;
 
 double round2(double value) {
-  int ivalue = (int)(value * 100.0 + (value > 0.0 ? 0.5 : -0.5));
+  int ivalue = (int) round(value * 100.0);
 
   // fix Marstek bug: make sure to have decimal numbers
   if(forcePwrDecimals && (ivalue % 100 == 0)) ivalue++;
-  
+
   return ivalue / 100.0;
 }
 

--- a/src/rpc/RpcComm.cpp
+++ b/src/rpc/RpcComm.cpp
@@ -184,7 +184,7 @@ void parseHttpRPC(String requestBody, AsyncWebServerRequest *request) {
         rpcWrapper();
         request->send(200, "application/json", serJsonResponse);
       } else {
-        DEBUG_SERIAL.printf("RPC over HTTP: unknown request: %s\n", requestBody);
+        DEBUG_SERIAL.printf("RPC over HTTP: unknown request: %s\n", requestBody.c_str());
       }
     }
   }


### PR DESCRIPTION
This PR removes legacy rounding-side effects from the power processing path and simplifies the implementation.

Previously, `round2` was doing more than rounding: when `forcePwrDecimals` was enabled, exact `.00` values were intentionally changed to `.01` as a workaround for a Marstek-specific issue. That meant the core data path could alter valid measured values just to influence output formatting.

With this change, `round2` is now a pure 2-decimal rounding helper again, and the `forcePwrDecimals` setting has been removed from configuration, persistence, and WiFiManager. This reduces complexity and prevents hidden measurement bias in power-related values.

The result is simpler code, more predictable behavior, and numerically correct output. Any formatting-specific compatibility handling should happen at the serialization/output layer rather than by modifying computed values.