### PR TITLE
Add optional power offset and fix WifiManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ Connect your ESP to your PC using USB and follow the instructions on the [webfla
   
   The Shelly ID defaults to the ESP's MAC address, you may change this if you want to substitute an existing uni-meter configuration without reconnecting the battery to a new shelly device.
   
+  #### Power offset option:
+  - This option allows a positive or negative value to be added to the emulated Shelly's output data
+  
   #### How the <code>phase_number</code> option can be used:
   - If you have a monophase setup, set <code>phase_number</code> to <code>1</code>. This asigns all power and energy data to phase 1.
   - If you have a triphase setup, set <code>phase_number</code> to <code>3</code>. This distributes power and energy data across all three phases.

--- a/src/config/Configuration.cpp
+++ b/src/config/Configuration.cpp
@@ -16,6 +16,7 @@ char input_type[40];
 char ntp_server[40] = "de.pool.ntp.org";
 char timezone[64] = "CET-1CEST,M3.5.0/2,M10.5.0/3"; // Central European Time
 char phase_number[2] = "3"; // number of phases: 1 for monophase or 3 for triphase
+char power_offset[10] = "0";  // Default: no offset
 char mqtt_server[160];
 char mqtt_port[6] = "1883";
 char mqtt_topic[90] = "tele/meter/SENSOR";
@@ -155,6 +156,7 @@ void WifiManagerSetup() {
   strcpy(ntp_server, preferences.getString("ntp_server", ntp_server).c_str());
   strcpy(timezone, preferences.getString("timezone", timezone).c_str());
   strcpy(phase_number, preferences.getString("phase_number", phase_number).c_str());
+  strcpy(power_offset, preferences.getString("power_offset", power_offset).c_str());
   strcpy(query_period, preferences.getString("query_period", query_period).c_str());
   strcpy(led_gpio, preferences.getString("led_gpio", led_gpio).c_str());
   strcpy(led_gpio_i, preferences.getString("led_gpio_i", led_gpio_i).c_str());
@@ -191,6 +193,7 @@ void WifiManagerSetup() {
   WiFiManagerParameter param_ntp_server("ntp_server", "NTP server <span title=\"for time synchronization\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", ntp_server, 40);
   WiFiManagerParameter param_timezone("timezone", "Timezone <span title=\"e.g. UTC0, UTC+1, UTC-3, UTC+1CET-1CEST,M3.5.0/02:00:00,M10.5.0/03:00:00\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", timezone, 64);
   WiFiManagerParameter param_phase_number("phase_number", "Number of phases <span title=\"Number of phases (e.g. 1 or 3)\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", phase_number, 1);
+  WiFiManagerParameter custom_power_offset("power_offset", "<b>Power Offset</b><br>optional offset value in Watts added to the emulated output ", power_offset, 10);
   WiFiManagerParameter custom_query_period("query_period", "<b>Query period</b><br>for generic HTTP and SUNSPEC, in milliseconds", query_period, 10);
   WiFiManagerParameter custom_led_gpio("led_gpio", "<b>GPIO</b><br>of internal LED", led_gpio, 3);
   WiFiManagerParameter custom_led_gpio_i("led_gpio_i", "<b>GPIO is inverted</b><br><code>true</code> or <code>false</code>", led_gpio_i, 6);
@@ -227,6 +230,10 @@ void WifiManagerSetup() {
   if (!DEBUG) {
     wifiManager.setDebugOutput(false);
   }
+
+  wifiManager.setDebugOutput(true, WM_DEBUG_DEV);
+  wifiManager.debugPlatformInfo();
+
   wifiManager.setTitle("Energy2Shelly for ESP");
   wifiManager.setSaveConfigCallback(saveConfigCallback);
 
@@ -239,6 +246,7 @@ void WifiManagerSetup() {
   wifiManager.addParameter(&param_ntp_server);
   wifiManager.addParameter(&param_timezone);
   wifiManager.addParameter(&param_phase_number);
+  wifiManager.addParameter(&custom_power_offset);
   wifiManager.addParameter(&custom_query_period);
   wifiManager.addParameter(&custom_led_gpio);
   wifiManager.addParameter(&custom_led_gpio_i);
@@ -284,6 +292,7 @@ void WifiManagerSetup() {
   strcpy(ntp_server, param_ntp_server.getValue());
   strcpy(timezone, param_timezone.getValue());
   strcpy(phase_number, param_phase_number.getValue());
+  strcpy(power_offset, custom_power_offset.getValue());
   strcpy(query_period, custom_query_period.getValue());
   strcpy(led_gpio, custom_led_gpio.getValue());
   strcpy(led_gpio_i, custom_led_gpio_i.getValue());
@@ -314,6 +323,7 @@ void WifiManagerSetup() {
   DEBUG_SERIAL.println("\tntp_server: " + String(ntp_server));
   DEBUG_SERIAL.println("\ttimezone: " + String(timezone));
   DEBUG_SERIAL.println("\tphase_number : " + String(phase_number));
+  DEBUG_SERIAL.println("\tpower_offset : " + String(power_offset));
   DEBUG_SERIAL.println("\tquery_period : " + String(query_period));
   DEBUG_SERIAL.println("\tled_gpio : " + String(led_gpio));
   DEBUG_SERIAL.println("\tled_gpio_i : " + String(led_gpio_i));
@@ -371,6 +381,7 @@ void WifiManagerSetup() {
     preferences.putString("ntp_server", ntp_server);
     preferences.putString("timezone", timezone);
     preferences.putString("phase_number", phase_number);
+    preferences.putString("power_offset", power_offset);
     preferences.putString("query_period", query_period);
     preferences.putString("led_gpio", led_gpio);
     preferences.putString("led_gpio_i", led_gpio_i);

--- a/src/config/Configuration.cpp
+++ b/src/config/Configuration.cpp
@@ -67,10 +67,11 @@ IPAddress modbus_ip;
 ModbusIP modbus1;
 int16_t modbus_result[256];
 
-// Default electrical values
+// Default electrical values and offset
 const uint8_t defaultVoltage = 230;
 const uint8_t defaultFrequency = 50;
 const uint8_t defaultPowerFactor = 1;
+double offsetPerPhase = 0;
 
 // RPC and query settings
 unsigned long period = 1000;
@@ -234,6 +235,10 @@ void WifiManagerSetup() {
   wifiManager.setDebugOutput(true, WM_DEBUG_DEV);
   wifiManager.debugPlatformInfo();
 
+  // Move custom parameters to seperate menu to avoid issues with too many custom parameters and too many results from AP scan
+  std::vector<const char *> menu = {"wifi","info","param","sep","restart","exit"};
+  wifiManager.setMenu(menu);
+
   wifiManager.setTitle("Energy2Shelly for ESP");
   wifiManager.setSaveConfigCallback(saveConfigCallback);
 
@@ -314,6 +319,8 @@ void WifiManagerSetup() {
   strcpy(tibber_url, param_tibber_url.getValue());
   strcpy(tibber_user, param_tibber_user.getValue());
   strcpy(tibber_password, param_tibber_password.getValue());
+
+  offsetPerPhase = String(power_offset).toDouble() / 3.0;  // distribute offset equally across phases
 
   DEBUG_SERIAL.println("The values in the preferences are: ");
   DEBUG_SERIAL.println("\treset_password: ********");

--- a/src/config/Configuration.cpp
+++ b/src/config/Configuration.cpp
@@ -194,7 +194,7 @@ void WifiManagerSetup() {
   WiFiManagerParameter param_ntp_server("ntp_server", "NTP server <span title=\"for time synchronization\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", ntp_server, 40);
   WiFiManagerParameter param_timezone("timezone", "Timezone <span title=\"e.g. UTC0, UTC+1, UTC-3, UTC+1CET-1CEST,M3.5.0/02:00:00,M10.5.0/03:00:00\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", timezone, 64);
   WiFiManagerParameter param_phase_number("phase_number", "Number of phases <span title=\"Number of phases (e.g. 1 or 3)\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", phase_number, 1);
-  WiFiManagerParameter custom_power_offset("power_offset", "<b>Power Offset</b><br>optional offset value in Watts added to the emulated output ", power_offset, 10);
+  WiFiManagerParameter custom_power_offset("power_offset", "Power offset <span title=\"optional offset value in Watts added to the emulated output\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", power_offset, 10);
   WiFiManagerParameter custom_query_period("query_period", "<b>Query period</b><br>for generic HTTP and SUNSPEC, in milliseconds", query_period, 10);
   WiFiManagerParameter custom_led_gpio("led_gpio", "<b>GPIO</b><br>of internal LED", led_gpio, 3);
   WiFiManagerParameter custom_led_gpio_i("led_gpio_i", "<b>GPIO is inverted</b><br><code>true</code> or <code>false</code>", led_gpio_i, 6);

--- a/src/config/Configuration.h
+++ b/src/config/Configuration.h
@@ -53,6 +53,7 @@ extern char input_type[40];
 extern char ntp_server[40];
 extern char timezone[64];
 extern char phase_number[2];
+extern char power_offset[10];
 extern char mqtt_server[160];
 extern char mqtt_port[6];
 extern char mqtt_topic[90];

--- a/src/config/Configuration.h
+++ b/src/config/Configuration.h
@@ -103,10 +103,11 @@ extern IPAddress modbus_ip;
 extern ModbusIP modbus1;
 extern int16_t modbus_result[256];
 
-// Default electrical values
+// Default electrical values and offset
 extern const uint8_t defaultVoltage;
 extern const uint8_t defaultFrequency;
 extern const uint8_t defaultPowerFactor;
+extern double offsetPerPhase;
 
 // RPC and query settings
 extern unsigned long period;

--- a/src/data/DataProcessing.cpp
+++ b/src/data/DataProcessing.cpp
@@ -34,17 +34,19 @@ JsonVariant resolveJsonPath(JsonVariant variant, const char *path) {
 }
 
 void setPowerData(double totalPower) {
+  double adjustedPower = totalPower + String(power_offset).toDouble();
+
   switch(phase_number[0]) {
     case '1': // monophase
-      PhasePower[0].power = round2(totalPower);
+      PhasePower[0].power = round2(adjustedPower);
       PhasePower[1].power = 0.0;
       PhasePower[2].power = 0.0;
       break;
     case '3': // triphase
     default:
-      PhasePower[0].power = round2(totalPower * 0.3333);
-      PhasePower[1].power = round2(totalPower * 0.3333);
-      PhasePower[2].power = round2(totalPower * 0.3333);
+      PhasePower[0].power = round2(adjustedPower * 0.3333);
+      PhasePower[1].power = round2(adjustedPower * 0.3333);
+      PhasePower[2].power = round2(adjustedPower * 0.3333);
       break;
   }
   for (int i = 0; i <= 2; i++) {
@@ -54,22 +56,24 @@ void setPowerData(double totalPower) {
     PhasePower[i].powerFactor = round2(defaultPowerFactor);
     PhasePower[i].frequency = defaultFrequency;
   }
-  DEBUG_SERIAL.print("Current total power: ");
-  DEBUG_SERIAL.println(totalPower);
+  DEBUG_SERIAL.print("Current total power (with offset): ");
+  DEBUG_SERIAL.println(adjustedPower);
 }
 
 void setPowerData(double phase1Power, double phase2Power, double phase3Power) {
+  double offsetPerPhase = String(power_offset).toDouble() / 3.0;  // distribute offset equally across phases
+  
   switch(phase_number[0]) {
     case '1': // monophase
-      PhasePower[0].power = round2(phase1Power) + round2(phase2Power) + round2(phase3Power);
+      PhasePower[0].power = round2(phase1Power) + round2(phase2Power) + round2(phase3Power) + offsetPerPhase * 3;
       PhasePower[1].power = 0.0;
       PhasePower[2].power = 0.0;
       break;
     case '3': // triphase
     default:
-      PhasePower[0].power = round2(phase1Power);
-      PhasePower[1].power = round2(phase2Power);
-      PhasePower[2].power = round2(phase3Power);
+      PhasePower[0].power = round2(phase1Power + offsetPerPhase);
+      PhasePower[1].power = round2(phase2Power + offsetPerPhase);
+      PhasePower[2].power = round2(phase3Power + offsetPerPhase);
       break;
   }
   for (int i = 0; i <= 2; i++) {
@@ -79,12 +83,12 @@ void setPowerData(double phase1Power, double phase2Power, double phase3Power) {
     PhasePower[i].powerFactor = round2(defaultPowerFactor);
     PhasePower[i].frequency = defaultFrequency;
   }
-  DEBUG_SERIAL.print("Current power L1: ");
-  DEBUG_SERIAL.print(phase1Power);
+  DEBUG_SERIAL.print("Current power (with offset) L1: ");
+  DEBUG_SERIAL.print(phase1Power + offsetPerPhase);
   DEBUG_SERIAL.print(" - L2: ");
-  DEBUG_SERIAL.print(phase2Power);
+  DEBUG_SERIAL.print(phase2Power + offsetPerPhase);
   DEBUG_SERIAL.print(" - L3: ");
-  DEBUG_SERIAL.println(phase3Power);
+  DEBUG_SERIAL.println(phase3Power + offsetPerPhase);
 }
 
 void setEnergyData(double totalEnergyGridSupply, double totalEnergyGridFeedIn) {
@@ -111,32 +115,34 @@ void setEnergyData(double totalEnergyGridSupply, double totalEnergyGridFeedIn) {
 
 void setJsonPathPower(JsonDocument json) {
   // If the incoming JSON already uses Shelly 3EM field names, parse directly
+  double offsetPerPhase = String(power_offset).toDouble() / 3.0;  // distribute offset equally across phases
+  
   if (json["a_current"].is<JsonVariant>() || json["a_act_power"].is<JsonVariant>()) {
     DEBUG_SERIAL.println("Parsing direct Shelly 3EM payload");
     PhasePower[0].current = round2((double)json["a_current"].as<double>());
     PhasePower[0].voltage = round2((double)json["a_voltage"].as<double>());
-    PhasePower[0].power = round2((double)json["a_act_power"].as<double>());
-    PhasePower[0].apparentPower = round2((double)json["a_aprt_power"].as<double>());
+    PhasePower[0].power = round2((double)json["a_act_power"].as<double>() + offsetPerPhase);
+    PhasePower[0].apparentPower = round2((double)json["a_aprt_power"].as<double>() + offsetPerPhase);
     PhasePower[0].powerFactor = round2((double)json["a_pf"].as<double>());
     PhasePower[0].frequency = json["a_freq"].as<int>();
 
     PhasePower[1].current = round2((double)json["b_current"].as<double>());
     PhasePower[1].voltage = round2((double)json["b_voltage"].as<double>());
-    PhasePower[1].power = round2((double)json["b_act_power"].as<double>());
-    PhasePower[1].apparentPower = round2((double)json["b_aprt_power"].as<double>());
+    PhasePower[1].power = round2((double)json["b_act_power"].as<double>() + offsetPerPhase);
+    PhasePower[1].apparentPower = round2((double)json["b_aprt_power"].as<double>() + offsetPerPhase);
     PhasePower[1].powerFactor = round2((double)json["b_pf"].as<double>());
     PhasePower[1].frequency = json["b_freq"].as<int>();
 
     PhasePower[2].current = round2((double)json["c_current"].as<double>());
     PhasePower[2].voltage = round2((double)json["c_voltage"].as<double>());
-    PhasePower[2].power = round2((double)json["c_act_power"].as<double>());
-    PhasePower[2].apparentPower = round2((double)json["c_aprt_power"].as<double>());
+    PhasePower[2].power = round2((double)json["c_act_power"].as<double>() + offsetPerPhase);
+    PhasePower[2].apparentPower = round2((double)json["c_aprt_power"].as<double>() + offsetPerPhase);
     PhasePower[2].powerFactor = round2((double)json["c_pf"].as<double>());
     PhasePower[2].frequency = json["c_freq"].as<int>();
 
     // Optionally use total fields if present
     if (json["total_act_power"].is<JsonVariant>()) {
-      double total = json["total_act_power"].as<double>();
+      double total = json["total_act_power"].as<double>() + offsetPerPhase * 3;
       // distribute if individual phases missing or for logging
       DEBUG_SERIAL.print("Total power from payload: ");
       DEBUG_SERIAL.println(total);

--- a/src/data/DataProcessing.cpp
+++ b/src/data/DataProcessing.cpp
@@ -34,7 +34,7 @@ JsonVariant resolveJsonPath(JsonVariant variant, const char *path) {
 }
 
 void setPowerData(double totalPower) {
-  double adjustedPower = totalPower + String(power_offset).toDouble();
+  double adjustedPower = totalPower + offsetPerPhase * 3;
 
   switch(phase_number[0]) {
     case '1': // monophase
@@ -61,8 +61,6 @@ void setPowerData(double totalPower) {
 }
 
 void setPowerData(double phase1Power, double phase2Power, double phase3Power) {
-  double offsetPerPhase = String(power_offset).toDouble() / 3.0;  // distribute offset equally across phases
-  
   switch(phase_number[0]) {
     case '1': // monophase
       PhasePower[0].power = round2(phase1Power) + round2(phase2Power) + round2(phase3Power) + offsetPerPhase * 3;

--- a/src/parsers/SmaParser.cpp
+++ b/src/parsers/SmaParser.cpp
@@ -77,14 +77,14 @@ void parseSMA() {
                 // 2.4.0 Total feed-in power in dW - unused
                 break;
               case 21:
-                PhasePower[0].power = round2(data * 0.1);
+                PhasePower[0].power = round2(data * 0.1) - offsetPerPhase;
                 PhasePower[0].frequency = defaultFrequency;
                 break;
               case 22:
                 PhasePower[0].power -= round2(data * 0.1);
                 break;
               case 29:
-                PhasePower[0].apparentPower = round2(data * 0.1);
+                PhasePower[0].apparentPower = round2(data * 0.1) - offsetPerPhase;
                 break;
               case 30:
                 PhasePower[0].apparentPower -= round2(data * 0.1);
@@ -99,14 +99,14 @@ void parseSMA() {
                 PhasePower[0].powerFactor = round2(data * 0.001);
                 break;
               case 41:
-                PhasePower[1].power = round2(data * 0.1);
+                PhasePower[1].power = round2(data * 0.1) - offsetPerPhase;
                 PhasePower[1].frequency = defaultFrequency;
                 break;
               case 42:
                 PhasePower[1].power -= round2(data * 0.1);
                 break;
               case 49:
-                PhasePower[1].apparentPower = round2(data * 0.1);
+                PhasePower[1].apparentPower = round2(data * 0.1) - offsetPerPhase;
                 break;
               case 50:
                 PhasePower[1].apparentPower -= round2(data * 0.1);
@@ -121,14 +121,14 @@ void parseSMA() {
                 PhasePower[1].powerFactor = round2(data * 0.001);
                 break;
               case 61:
-                PhasePower[2].power = round2(data * 0.1);
+                PhasePower[2].power = round2(data * 0.1) - offsetPerPhase;
                 PhasePower[2].frequency = defaultFrequency;
                 break;
               case 62:
                 PhasePower[2].power -= round2(data * 0.1);
                 break;
               case 69:
-                PhasePower[2].apparentPower = round2(data * 0.1);
+                PhasePower[2].apparentPower = round2(data * 0.1) - offsetPerPhase;
                 break;
               case 70:
                 PhasePower[2].apparentPower -= round2(data * 0.1);

--- a/src/parsers/SunspecParser.cpp
+++ b/src/parsers/SunspecParser.cpp
@@ -62,8 +62,8 @@ void parseSUNSPEC() {
       double scale_frequency=SUNSPEC_scale(modbus_result[SUNSPEC_FREQUENCY_SCALE-SUNSPEC_BASE]);
 
       for (int n=0;n<3;n++) {
-        PhasePower[n].power=modbus_result[SUNSPEC_REAL_POWER-SUNSPEC_BASE+n]*scale_real_power;
-        PhasePower[n].apparentPower=modbus_result[SUNSPEC_APPARANT_POWER-SUNSPEC_BASE+n]*scale_apparant_power;
+        PhasePower[n].power=modbus_result[SUNSPEC_REAL_POWER-SUNSPEC_BASE+n]*scale_real_power + offsetPerPhase * 3;
+        PhasePower[n].apparentPower=modbus_result[SUNSPEC_APPARANT_POWER-SUNSPEC_BASE+n]*scale_apparant_power + offsetPerPhase * 3;
         PhasePower[n].current= modbus_result[SUNSPEC_CURRENT-SUNSPEC_BASE+n]*scale_current;
         PhasePower[n].powerFactor=modbus_result[SUNSPEC_POWER_FACTOR-SUNSPEC_BASE+n]*scale_powerfactor;
         PhasePower[n].voltage=modbus_result[SUNSPEC_VOLTAGE-SUNSPEC_BASE+n]*scale_V;


### PR DESCRIPTION
- Add optional power offset (#49)
- Move custom parameters to separate menu in WifiManager. WM showed issues with long lists of available APs leading to not showing the custom parameters anymore.