### PR TITLE
Tibber Pulse add configuration support for `nodeId`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Connect your ESP to your PC using USB and follow the instructions on the [webfla
   - <code>TIBBERPULSE</code>
     - Parses SML data from your Tibber Pulse IR locally using the [sml_parser](https://github.com/olliiiver/sml_parser) ESP library. This is a great option if you want to use Tibber Pulse data for zero feed-in with Hoymiles MS-A2, Growatt NOAH/NEXA, or Marstek Venus inverters/batteries.
     - Follow [these](https://github.com/marq24/ha-tibber-pulse-local#tibber-pulse-ir-local) instructions to access your Tibber Pulse/Bridge data locally.
-    - Provide the `IP address / hostname` and `port` of the WebSocket API, plus `username` and `password` of your Tibber Bridge, in the configuration options so Energy2Shelly_ESP can connect and receive power data.
+    - Provide the `IP address / hostname` and `port` of the WebSocket API, the `node id` of your Pulse IR in the Bridge configuration, plus `username` and `password` of your Tibber Bridge, in the configuration options so Energy2Shelly_ESP can connect and receive power data.
     - The parser automatically extracts `total power`, `phase power` and `energy from/to the grid` from the WebSocket API data stream and makes it available for the Shelly Pro 3EM Emulator.
     - Following power meters are currently supported and implemented in the parser:
       - **EMH EHZB** (SML message length: 248)

--- a/src/config/Configuration.cpp
+++ b/src/config/Configuration.cpp
@@ -46,11 +46,10 @@ bool forcePwrDecimals = true; // to fix Marstek bug
 char sma_id[17] = "";
 
 // Tibber related
-char tibber_host_port[41] = "x.x.x.x[:xxxx]"; // IP/FQDN (and PORT) of Tibber Pulse Bridge device
-char tibber_user[11] = "admin"; // fixed user
-char tibber_password[10] = "xxxx-xxxx"; // replace with password printed on your Tibber Pulse Bridge device
-char tibber_rpc[25] = "/data.json?node_id="; // fixed rpc path
-char tibber_nodeid[2] = "1"; // node id, defaults to "1", can be changed in the config portal
+char tibber_url[41] = "x.x.x.x[:xxxx]"; // IP of TibberPulse
+char tibber_user[6] = "admin";         // fixed user
+char tibber_password[10] = "xxxx-xxxx"; // replace with password printed on Tibbel-Pulse-Adapter
+char tibber_rpc[21] = "/data.json?node_id=1"; // fixed rpc path
 
 // LED settings
 char led_gpio[3] = "";
@@ -178,10 +177,9 @@ void WifiManagerSetup() {
   strcpy(force_pwr_decimals, preferences.getString("force_pwr_decimals", force_pwr_decimals).c_str());
   strcpy(sma_id, preferences.getString("sma_id", sma_id).c_str());
   // TibberPulse settings
-  strcpy(tibber_host_port, preferences.getString("tibber_host_port", tibber_host_port).c_str());
+  strcpy(tibber_url, preferences.getString("tibber_url", tibber_url).c_str());
   strcpy(tibber_user, preferences.getString("tibber_user", tibber_user).c_str());
   strcpy(tibber_password, preferences.getString("tibber_password", tibber_password).c_str());
-  strcpy(tibber_nodeid, preferences.getString("tibber_nodeid", tibber_nodeid).c_str());
 
   const char *show_pwd_str = "<input type=\"checkbox\" onclick=\"t('%s')\">&nbsp;<label>Show password</label><br/>";
 
@@ -222,13 +220,12 @@ void WifiManagerSetup() {
   WiFiManagerParameter custom_energy_out_path("energy_out_path", "<b>Energy to grid JSON path</b><br>e.g. <code>ENERGY.FeedIn</code>", energy_out_path, 60);
   // TibberPulse section
   WiFiManagerParameter param_section_tibberpulse("<hr><h3>TibberPulse options</h3>");
-  WiFiManagerParameter param_tibber_host_port("tibber_host_port", "Hostname/IP[:port] <span title=\"e.g.: 192.168.0.1:8080\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", tibber_host_port, 40);
-  WiFiManagerParameter param_tibber_user("tibber_user", "User <span title=\"defaults to: admin\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", tibber_user, 10);
+  WiFiManagerParameter param_tibber_url("tibber_url", "Hostname/IP[:port] <span title=\"e.g.: 192.168.0.1:8080\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", tibber_url, 40);
+  WiFiManagerParameter param_tibber_user("tibber_user", "User <span title=\"defaults to: admin\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", tibber_user, 5);
   WiFiManagerParameter param_tibber_password("tibber_password", "Password <span title=\"as printed on bridge device: xxxx-xxxx\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", tibber_password, 9, "type='password'");
   char buf_tibber_pwd_show_pwd[150];
   sprintf(buf_tibber_pwd_show_pwd, show_pwd_str, "tibber_password");
   WiFiManagerParameter param_tibber_password_show_password(buf_tibber_pwd_show_pwd);
-  WiFiManagerParameter param_tibber_nodeid("tibber_nodeid", "Node ID <span title=\"defaults to: 1, up to 9 node ID supported.\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", tibber_nodeid, 1);
 
   WiFiManager wifiManager;
   if (!DEBUG) {
@@ -271,11 +268,10 @@ void WifiManagerSetup() {
   wifiManager.addParameter(&custom_energy_out_path);
   // TibberPulse section
   wifiManager.addParameter(&param_section_tibberpulse);
-  wifiManager.addParameter(&param_tibber_host_port);
+  wifiManager.addParameter(&param_tibber_url);
   wifiManager.addParameter(&param_tibber_user);
   wifiManager.addParameter(&param_tibber_password);
   wifiManager.addParameter(&param_tibber_password_show_password);
-  wifiManager.addParameter(&param_tibber_nodeid);
 
   if (!wifiManager.autoConnect("Energy2Shelly")) {
     DEBUG_SERIAL.println("failed to connect and hit timeout");
@@ -312,8 +308,7 @@ void WifiManagerSetup() {
   strcpy(force_pwr_decimals, custom_force_pwr_decimals.getValue());
   strcpy(sma_id, custom_sma_id.getValue());
   // TibberPulse
-  strcpy(tibber_host_port, param_tibber_host_port.getValue());
-  strcpy(tibber_nodeid, param_tibber_nodeid.getValue());
+  strcpy(tibber_url, param_tibber_url.getValue());
   strcpy(tibber_user, param_tibber_user.getValue());
   strcpy(tibber_password, param_tibber_password.getValue());
 
@@ -344,10 +339,9 @@ void WifiManagerSetup() {
   DEBUG_SERIAL.println("\tforce_pwr_decimals : " + String(force_pwr_decimals));
   DEBUG_SERIAL.println("\tsma_id : " + String(sma_id));
   DEBUG_SERIAL.println("\tTibberPulse options:");
-  DEBUG_SERIAL.println("\t - tibber_host_port: " + String(tibber_host_port));
+  DEBUG_SERIAL.println("\t - tibber_url: " + String(tibber_url));
   DEBUG_SERIAL.println("\t - tibber_user: " + String(tibber_user));
   DEBUG_SERIAL.println("\t - tibber_password: ********");
-  DEBUG_SERIAL.println("\t - tibber_nodeid: " + String(tibber_nodeid));
 
   if (strcmp(input_type, "SMA") == 0) {
     dataSMA = true;
@@ -408,10 +402,9 @@ void WifiManagerSetup() {
     preferences.putString("shelly_port", shelly_port);
     preferences.putString("force_pwr_decimals", force_pwr_decimals);
     preferences.putString("sma_id", sma_id);
-    preferences.putString("tibber_host_port", tibber_host_port);
+    preferences.putString("tibber_url", tibber_url);
     preferences.putString("tibber_user", tibber_user);
     preferences.putString("tibber_password", tibber_password);
-    preferences.putString("tibber_nodeid", tibber_nodeid);
     wifiManager.reboot();
   }
   DEBUG_SERIAL.println("local ip");

--- a/src/config/Configuration.cpp
+++ b/src/config/Configuration.cpp
@@ -45,10 +45,11 @@ char modbus_dev[10] = "71"; // default for KSEM
 char sma_id[17] = "";
 
 // Tibber related
-char tibber_url[41] = "x.x.x.x[:xxxx]"; // IP of TibberPulse
-char tibber_user[6] = "admin";         // fixed user
-char tibber_password[10] = "xxxx-xxxx"; // replace with password printed on Tibbel-Pulse-Adapter
-char tibber_rpc[21] = "/data.json?node_id=1"; // fixed rpc path
+char tibber_host[41] = "x.x.x.x[:xxxx]"; // IP / HOSTNAME [and PORT] of Tibber Pulse Bridge
+char tibber_user[11] = "admin"; // fixed user
+char tibber_password[10] = "xxxx-xxxx"; // replace with password printed on Tibber Pulse Bridge device
+char tibber_rpc[21] = "/data.json?node_id="; // fixed rpc path
+char tibber_nodeid[2] = "1"; // node id of the Pulse IR device, defaults to 1. if reparing this might change, check the node id in the web interface of the Tibber Pulse Bridge device
 
 // LED settings
 char led_gpio[3] = "";
@@ -177,7 +178,8 @@ void WifiManagerSetup() {
   strcpy(shelly_port, preferences.getString("shelly_port", shelly_port).c_str());
   strcpy(sma_id, preferences.getString("sma_id", sma_id).c_str());
   // TibberPulse settings
-  strcpy(tibber_url, preferences.getString("tibber_url", tibber_url).c_str());
+  strcpy(tibber_host, preferences.getString("tibber_host", tibber_host).c_str());
+  strcpy(tibber_nodeid, preferences.getString("tibber_nodeid", tibber_nodeid).c_str());
   strcpy(tibber_user, preferences.getString("tibber_user", tibber_user).c_str());
   strcpy(tibber_password, preferences.getString("tibber_password", tibber_password).c_str());
 
@@ -220,9 +222,10 @@ void WifiManagerSetup() {
   WiFiManagerParameter custom_energy_out_path("energy_out_path", "<b>Energy to grid JSON path</b><br>e.g. <code>ENERGY.FeedIn</code>", energy_out_path, 60);
   // TibberPulse section
   WiFiManagerParameter param_section_tibberpulse("<hr><h3>TibberPulse options</h3>");
-  WiFiManagerParameter param_tibber_url("tibber_url", "Hostname/IP[:port] <span title=\"e.g.: 192.168.0.1:8080\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", tibber_url, 40);
-  WiFiManagerParameter param_tibber_user("tibber_user", "User <span title=\"defaults to: admin\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", tibber_user, 5);
-  WiFiManagerParameter param_tibber_password("tibber_password", "Password <span title=\"as printed on bridge device: xxxx-xxxx\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", tibber_password, 9, "type='password'");
+  WiFiManagerParameter param_tibber_host_port("tibber_host_port", "Hostname/IP[:port] <span title=\"e.g.: 192.168.0.1:8080\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", tibber_host, 40);
+  WiFiManagerParameter param_tibber_node_id("tibber_node_id", "Node ID <span title=\"defaults to: 1, check the bridge web interface for the right nodeId\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", tibber_nodeid, 1);
+  WiFiManagerParameter param_tibber_user("tibber_user", "User <span title=\"defaults to: admin\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", tibber_user, 10);
+  WiFiManagerParameter param_tibber_password("tibber_password", "Password <span title=\"as printed on bridge device: xxxx-xxxx\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", tibber_password, 10, "type='password'");
   char buf_tibber_pwd_show_pwd[150];
   sprintf(buf_tibber_pwd_show_pwd, show_pwd_str, "tibber_password");
   WiFiManagerParameter param_tibber_password_show_password(buf_tibber_pwd_show_pwd);
@@ -273,7 +276,8 @@ void WifiManagerSetup() {
   wifiManager.addParameter(&custom_energy_out_path);
   // TibberPulse section
   wifiManager.addParameter(&param_section_tibberpulse);
-  wifiManager.addParameter(&param_tibber_url);
+  wifiManager.addParameter(&param_tibber_host_port);
+  wifiManager.addParameter(&param_tibber_node_id);
   wifiManager.addParameter(&param_tibber_user);
   wifiManager.addParameter(&param_tibber_password);
   wifiManager.addParameter(&param_tibber_password_show_password);
@@ -313,7 +317,8 @@ void WifiManagerSetup() {
   strcpy(shelly_port, custom_shelly_port.getValue());
   strcpy(sma_id, custom_sma_id.getValue());
   // TibberPulse
-  strcpy(tibber_url, param_tibber_url.getValue());
+  strcpy(tibber_host, param_tibber_host_port.getValue());
+  strcpy(tibber_nodeid, param_tibber_node_id.getValue());
   strcpy(tibber_user, param_tibber_user.getValue());
   strcpy(tibber_password, param_tibber_password.getValue());
 
@@ -369,8 +374,10 @@ void WifiManagerSetup() {
   DEBUG_SERIAL.print(F("\tsma_id : "));
   DEBUG_SERIAL.println(String(sma_id));
   DEBUG_SERIAL.println(F("\tTibberPulse options:"));
-  DEBUG_SERIAL.print(F("\t - tibber_url: "));
-  DEBUG_SERIAL.println(String(tibber_url));
+  DEBUG_SERIAL.print(F("\t - tibber_host: "));
+  DEBUG_SERIAL.println(String(tibber_host));
+  DEBUG_SERIAL.print(F("\t - tibber_nodeid: "));
+  DEBUG_SERIAL.println(String(tibber_nodeid));
   DEBUG_SERIAL.print(F("\t - tibber_user: "));
   DEBUG_SERIAL.println(String(tibber_user));
   DEBUG_SERIAL.print(F("\t - tibber_password: ********"));
@@ -428,7 +435,8 @@ void WifiManagerSetup() {
     preferences.putString("energy_out_path", energy_out_path);
     preferences.putString("shelly_port", shelly_port);
     preferences.putString("sma_id", sma_id);
-    preferences.putString("tibber_url", tibber_url);
+    preferences.putString("tibber_host", tibber_host);
+    preferences.putString("tibber_nodeid", tibber_nodeid);
     preferences.putString("tibber_user", tibber_user);
     preferences.putString("tibber_password", tibber_password);
     wifiManager.reboot();

--- a/src/config/Configuration.cpp
+++ b/src/config/Configuration.cpp
@@ -46,10 +46,11 @@ bool forcePwrDecimals = true; // to fix Marstek bug
 char sma_id[17] = "";
 
 // Tibber related
-char tibber_url[41] = "x.x.x.x[:xxxx]"; // IP of TibberPulse
-char tibber_user[6] = "admin";         // fixed user
-char tibber_password[10] = "xxxx-xxxx"; // replace with password printed on Tibbel-Pulse-Adapter
-char tibber_rpc[21] = "/data.json?node_id=1"; // fixed rpc path
+char tibber_host_port[41] = "x.x.x.x[:xxxx]"; // IP/FQDN (and PORT) of Tibber Pulse Bridge device
+char tibber_user[11] = "admin"; // fixed user
+char tibber_password[10] = "xxxx-xxxx"; // replace with password printed on your Tibber Pulse Bridge device
+char tibber_rpc[25] = "/data.json?node_id="; // fixed rpc path
+char tibber_nodeid[2] = "1"; // node id, defaults to "1", can be changed in the config portal
 
 // LED settings
 char led_gpio[3] = "";
@@ -177,9 +178,10 @@ void WifiManagerSetup() {
   strcpy(force_pwr_decimals, preferences.getString("force_pwr_decimals", force_pwr_decimals).c_str());
   strcpy(sma_id, preferences.getString("sma_id", sma_id).c_str());
   // TibberPulse settings
-  strcpy(tibber_url, preferences.getString("tibber_url", tibber_url).c_str());
+  strcpy(tibber_host_port, preferences.getString("tibber_host_port", tibber_host_port).c_str());
   strcpy(tibber_user, preferences.getString("tibber_user", tibber_user).c_str());
   strcpy(tibber_password, preferences.getString("tibber_password", tibber_password).c_str());
+  strcpy(tibber_nodeid, preferences.getString("tibber_nodeid", tibber_nodeid).c_str());
 
   const char *show_pwd_str = "<input type=\"checkbox\" onclick=\"t('%s')\">&nbsp;<label>Show password</label><br/>";
 
@@ -220,12 +222,13 @@ void WifiManagerSetup() {
   WiFiManagerParameter custom_energy_out_path("energy_out_path", "<b>Energy to grid JSON path</b><br>e.g. <code>ENERGY.FeedIn</code>", energy_out_path, 60);
   // TibberPulse section
   WiFiManagerParameter param_section_tibberpulse("<hr><h3>TibberPulse options</h3>");
-  WiFiManagerParameter param_tibber_url("tibber_url", "Hostname/IP[:port] <span title=\"e.g.: 192.168.0.1:8080\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", tibber_url, 40);
-  WiFiManagerParameter param_tibber_user("tibber_user", "User <span title=\"defaults to: admin\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", tibber_user, 5);
+  WiFiManagerParameter param_tibber_host_port("tibber_host_port", "Hostname/IP[:port] <span title=\"e.g.: 192.168.0.1:8080\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", tibber_host_port, 40);
+  WiFiManagerParameter param_tibber_user("tibber_user", "User <span title=\"defaults to: admin\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", tibber_user, 10);
   WiFiManagerParameter param_tibber_password("tibber_password", "Password <span title=\"as printed on bridge device: xxxx-xxxx\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", tibber_password, 9, "type='password'");
   char buf_tibber_pwd_show_pwd[150];
   sprintf(buf_tibber_pwd_show_pwd, show_pwd_str, "tibber_password");
   WiFiManagerParameter param_tibber_password_show_password(buf_tibber_pwd_show_pwd);
+  WiFiManagerParameter param_tibber_nodeid("tibber_nodeid", "Node ID <span title=\"defaults to: 1, up to 9 node ID supported.\" style=\"cursor: help;\" aria-label=\"Help\" tabindex=\"0\">(?)</span>", tibber_nodeid, 1);
 
   WiFiManager wifiManager;
   if (!DEBUG) {
@@ -268,10 +271,11 @@ void WifiManagerSetup() {
   wifiManager.addParameter(&custom_energy_out_path);
   // TibberPulse section
   wifiManager.addParameter(&param_section_tibberpulse);
-  wifiManager.addParameter(&param_tibber_url);
+  wifiManager.addParameter(&param_tibber_host_port);
   wifiManager.addParameter(&param_tibber_user);
   wifiManager.addParameter(&param_tibber_password);
   wifiManager.addParameter(&param_tibber_password_show_password);
+  wifiManager.addParameter(&param_tibber_nodeid);
 
   if (!wifiManager.autoConnect("Energy2Shelly")) {
     DEBUG_SERIAL.println("failed to connect and hit timeout");
@@ -308,7 +312,8 @@ void WifiManagerSetup() {
   strcpy(force_pwr_decimals, custom_force_pwr_decimals.getValue());
   strcpy(sma_id, custom_sma_id.getValue());
   // TibberPulse
-  strcpy(tibber_url, param_tibber_url.getValue());
+  strcpy(tibber_host_port, param_tibber_host_port.getValue());
+  strcpy(tibber_nodeid, param_tibber_nodeid.getValue());
   strcpy(tibber_user, param_tibber_user.getValue());
   strcpy(tibber_password, param_tibber_password.getValue());
 
@@ -339,9 +344,10 @@ void WifiManagerSetup() {
   DEBUG_SERIAL.println("\tforce_pwr_decimals : " + String(force_pwr_decimals));
   DEBUG_SERIAL.println("\tsma_id : " + String(sma_id));
   DEBUG_SERIAL.println("\tTibberPulse options:");
-  DEBUG_SERIAL.println("\t - tibber_url: " + String(tibber_url));
+  DEBUG_SERIAL.println("\t - tibber_host_port: " + String(tibber_host_port));
   DEBUG_SERIAL.println("\t - tibber_user: " + String(tibber_user));
   DEBUG_SERIAL.println("\t - tibber_password: ********");
+  DEBUG_SERIAL.println("\t - tibber_nodeid: " + String(tibber_nodeid));
 
   if (strcmp(input_type, "SMA") == 0) {
     dataSMA = true;
@@ -402,9 +408,10 @@ void WifiManagerSetup() {
     preferences.putString("shelly_port", shelly_port);
     preferences.putString("force_pwr_decimals", force_pwr_decimals);
     preferences.putString("sma_id", sma_id);
-    preferences.putString("tibber_url", tibber_url);
+    preferences.putString("tibber_host_port", tibber_host_port);
     preferences.putString("tibber_user", tibber_user);
     preferences.putString("tibber_password", tibber_password);
+    preferences.putString("tibber_nodeid", tibber_nodeid);
     wifiManager.reboot();
   }
   DEBUG_SERIAL.println("local ip");

--- a/src/config/Configuration.h
+++ b/src/config/Configuration.h
@@ -81,10 +81,11 @@ extern char query_period[10];
 extern char modbus_dev[10];
 extern char sma_id[17];
 
-extern char tibber_url[41];
-extern char tibber_user[6];
+extern char tibber_host[41];
+extern char tibber_user[11];
 extern char tibber_password[10];
 extern char tibber_rpc[21];
+extern char tibber_nodeid[2];
 
 // LED settings
 extern char led_gpio[3];

--- a/src/config/Configuration.h
+++ b/src/config/Configuration.h
@@ -82,11 +82,10 @@ extern char force_pwr_decimals[6];
 extern bool forcePwrDecimals;
 extern char sma_id[17];
 
-extern char tibber_host_port[41];
-extern char tibber_user[11];
+extern char tibber_url[41];
+extern char tibber_user[6];
 extern char tibber_password[10];
-extern char tibber_rpc[25];
-extern char tibber_nodeid[2];
+extern char tibber_rpc[21];
 
 // LED settings
 extern char led_gpio[3];

--- a/src/config/Configuration.h
+++ b/src/config/Configuration.h
@@ -82,10 +82,11 @@ extern char force_pwr_decimals[6];
 extern bool forcePwrDecimals;
 extern char sma_id[17];
 
-extern char tibber_url[41];
-extern char tibber_user[6];
+extern char tibber_host_port[41];
+extern char tibber_user[11];
 extern char tibber_password[10];
-extern char tibber_rpc[21];
+extern char tibber_rpc[25];
+extern char tibber_nodeid[2];
 
 // LED settings
 extern char led_gpio[3];

--- a/src/parsers/TibberPulseParser.cpp
+++ b/src/parsers/TibberPulseParser.cpp
@@ -41,8 +41,9 @@ bool parseTibberPulse() {
   int getlength = 0;
   DEBUG_SERIAL.print("Querying TibberPulse raw SML: ");
   String url = "http://";
-  url += String(tibber_url);
+  url += String(tibber_host_port);
   url += String(tibber_rpc);
+  url += String(tibber_nodeid);
   DEBUG_SERIAL.printf("URL:%s, user:%s\r\n", url.c_str(), tibber_user);
   http.begin(wifi_client, url);
   http.setAuthorization(tibber_user, tibber_password);

--- a/src/parsers/TibberPulseParser.cpp
+++ b/src/parsers/TibberPulseParser.cpp
@@ -41,8 +41,9 @@ bool parseTibberPulse() {
   int getlength = 0;
   DEBUG_SERIAL.print(F("Querying TibberPulse raw SML: "));
   String url = "http://";
-  url += String(tibber_url);
+  url += String(tibber_host);
   url += String(tibber_rpc);
+  url += String(tibber_nodeid);
   DEBUG_SERIAL.printf("URL:%s, user:%s\r\n", url.c_str(), tibber_user);
   http.begin(wifi_client, url);
   http.setAuthorization(tibber_user, tibber_password);

--- a/src/parsers/TibberPulseParser.cpp
+++ b/src/parsers/TibberPulseParser.cpp
@@ -41,9 +41,8 @@ bool parseTibberPulse() {
   int getlength = 0;
   DEBUG_SERIAL.print("Querying TibberPulse raw SML: ");
   String url = "http://";
-  url += String(tibber_host_port);
+  url += String(tibber_url);
   url += String(tibber_rpc);
-  url += String(tibber_nodeid);
   DEBUG_SERIAL.printf("URL:%s, user:%s\r\n", url.c_str(), tibber_user);
   http.begin(wifi_client, url);
   http.setAuthorization(tibber_user, tibber_password);


### PR DESCRIPTION
This PR adds support for configuring the Tibber Pulse `node id` instead of assuming the default value of `1`. This fixes setups where the Pulse IR device uses a different node ID, for example after re-pairing.

### Why
The Tibber Pulse integration previously hard coded the request path to `node_id=1`. That works for the default case, but it breaks when the connected Pulse IR is assigned a different node ID by the Tibber Bridge. This change makes the integration configurable and documents the requirement for users.

### What Changed
- added a dedicated Tibber Pulse `node id` configuration field
- persisted the node ID in preferences
- exposed the node ID in the WiFiManager configuration UI
- renamed `tibber_url` to `tibber_host` to better match its actual usage
- updated the Tibber Pulse parser to build the request URL using the configured node ID
- adjusted Tibber credential/config field sizes for consistency
- updated the README to mention the required node ID

### Testing
- `platformio run`

### Notes
Existing Tibber Pulse users may need to re-enter their Tibber host and node ID in configuration if they are migrating from older stored settings that used `tibber_url`.