### PR TITLE
Updates for HA Shelly integration

### DIFF
--- a/src/rpc/RpcComm.cpp
+++ b/src/rpc/RpcComm.cpp
@@ -57,6 +57,11 @@ void webSocketEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEve
             shellyGetStatus();
             rpcWrapper();
             webSocket.textAll(serJsonResponse);
+          } else if (json["method"] == "Shelly.ListMethods") {
+            strcpy(rpcUser, "EMPTY");
+            shellyListMethods();
+            rpcWrapper();
+            webSocket.textAll(serJsonResponse);
           } else if (json["method"] == "EM.GetStatus") {
             strcpy(rpcUser, json["src"]);
             EMGetStatus();
@@ -126,6 +131,10 @@ void parseUdpRPC() {
         shellyGetStatus();
         rpcWrapper();
         UdpRPC.UDPPRINT(serJsonResponse.c_str());
+      } else if (json["method"] == "Shelly.ListMethods") {
+        shellyListMethods();
+        rpcWrapper();
+        UdpRPC.UDPPRINT(serJsonResponse.c_str());
       } else if (json["method"] == "EM.GetStatus") {
         EMGetStatus();
         rpcWrapper();
@@ -169,6 +178,10 @@ void parseHttpRPC(String requestBody, AsyncWebServerRequest *request) {
         request->send(200, "application/json", serJsonResponse);
       } else if (json["method"] == "Shelly.GetStatus") {
         shellyGetStatus();
+        rpcWrapper();
+        request->send(200, "application/json", serJsonResponse);
+      } else if (json["method"] == "Shelly.ListMethods") {
+        shellyListMethods();
         rpcWrapper();
         request->send(200, "application/json", serJsonResponse);
       } else if (json["method"] == "EM.GetStatus") {

--- a/src/rpc/RpcHandlers.cpp
+++ b/src/rpc/RpcHandlers.cpp
@@ -270,6 +270,27 @@ void shellyGetStatus() {
 }
 
 // aligned with Shelly API docs
+// https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/Shelly#shellylistmethods-example
+void shellyListMethods() {
+  JsonDocument jsonResponse;
+  JsonArray methods = jsonResponse["methods"].to<JsonArray>();
+  methods.add("EM.GetStatus");
+  methods.add("EM.GetConfig");
+  methods.add("EMData.GetStatus");
+  methods.add("Shelly.GetComponents");
+  methods.add("Shelly.GetConfig");
+  methods.add("Shelly.GetDeviceInfo");
+  methods.add("Shelly.GetStatus");
+  methods.add("Sys.GetConfig");
+  methods.add("Sys.GetStatus");
+  methods.add("WiFi.GetStatus");
+  serializeJson(jsonResponse, serJsonResponse);
+  DEBUG_SERIAL.print(F("shellyListMethods: "));
+  DEBUG_SERIAL.println(serJsonResponse);
+  blinkled(ledblinkduration);
+}
+
+// aligned with Shelly API docs
 // https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/Wifi#wifigetstatus-example
 void wifiGetStatus() {
   bool wifiConnected = (WiFi.status() == WL_CONNECTED);

--- a/src/rpc/RpcHandlers.h
+++ b/src/rpc/RpcHandlers.h
@@ -14,6 +14,7 @@ void EMGetConfig();
 void shellyGetConfig();
 void shellyGetComponents();
 void shellyGetStatus();
+void shellyListMethods();
 void wifiGetStatus();
 
 #endif // RPC_HANDLERS_H


### PR DESCRIPTION
Add `Shelly.ListMethods` support to RPC handlers and websocket events.

## Summary:
This PR implements support for the `Shelly.ListMethods` RPC method across all communication interfaces (WebSocket, UDP, and HTTP), improving API compatibility and discoverability for Home Assistant integration and other clients.

## Changes:
- **RpcHandlers.cpp/h**: Added `shellyListMethods()` function that returns an array of supported RPC methods aligned with the official Shelly API documentation
  - Supported methods: `EM.GetStatus`, `EM.GetConfig`, `EMData.GetStatus`, `Shelly.GetComponents`, `Shelly.GetConfig`, `Shelly.GetDeviceInfo`, `Shelly.GetStatus`, `Sys.GetConfig`, `Sys.GetStatus`, `WiFi.GetStatus`
- **RpcComm.cpp**: Integrated `Shelly.ListMethods` handling into all three communication channels:
  - WebSocket events
  - UDP RPC parsing
  - HTTP RPC parsing

## Impact:
- Enables clients (including Home Assistant) to discover available RPC methods at runtime
- Improves API compliance with Shelly's documented interface
- No breaking changes; purely additive functionality