### PR TITLE
Add watchdog timer and web-based settings page

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,13 +23,14 @@
 
 void setup(void) {
   DEBUG_SERIAL.begin(115200);
-  WifiManagerSetup();
 
-  // Initialize watchdog timer (30s timeout)
+  // Initialize watchdog timer (30s timeout) - before WifiManagerSetup
 #ifdef ESP32
   esp_task_wdt_init(30, true);
   esp_task_wdt_add(NULL);
 #endif
+
+  WifiManagerSetup();
 
   // Initialize time via NTP
 #ifdef ESP32
@@ -49,6 +50,9 @@ void setup(void) {
     }
     DEBUG_SERIAL.println(F("Waiting for NTP time..."));
     delay(500);
+#ifdef ESP32
+    esp_task_wdt_reset();
+#endif
   }
   if (!ntp_success) {
     DEBUG_SERIAL.println(F("NTP timeout - setting default time"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,68 @@
 
 // Web content
 #include "web/html_home.h"
+#include <Preferences.h>
+
+void handleSettingsGet(AsyncWebServerRequest *request) {
+  String html = "<!DOCTYPE html><html><head><title>Energy2Shelly Settings</title>";
+  html += "<meta name='viewport' content='width=device-width, initial-scale=1'>";
+  html += "<style>body{font-family:Arial,sans-serif;max-width:600px;margin:0 auto;padding:20px;}";
+  html += "label{display:block;margin-top:15px;font-weight:bold;}";
+  html += "input,select{width:100%;padding:8px;margin-top:5px;box-sizing:border-box;}";
+  html += "button{margin-top:20px;padding:10px 20px;background:#007bff;color:white;border:none;border-radius:5px;cursor:pointer;}";
+  html += "button:hover{background:#0056b3;}</style></head><body>";
+  html += "<h1>Energy2Shelly Settings</h1>";
+  html += "<form method='POST'>";
+  html += "<label>Shelly UDP Port (1010 or 2220)</label>";
+  html += "<input name='shelly_port' value='" + String(shelly_port) + "'>";
+  html += "<label>Phase Number (1 or 3)</label>";
+  html += "<input name='phase_number' value='" + String(phase_number) + "'>";
+  html += "<label>Power Offset (W)</label>";
+  html += "<input name='power_offset' value='" + String(power_offset) + "'>";
+  html += "<label>Query Period (ms)</label>";
+  html += "<input name='query_period' value='" + String(query_period) + "'>";
+  html += "<label>Reset Password</label>";
+  html += "<input name='reset_password' type='password' value='" + String(reset_password) + "'>";
+  html += "<button type='submit'>Save</button>";
+  html += "</form>";
+  html += "<p><a href='/'>Back to Dashboard</a></p>";
+  html += "</body></html>";
+  request->send(200, "text/html", html);
+}
+
+void handleSettingsPost(AsyncWebServerRequest *request) {
+  Preferences prefs;
+  prefs.begin("settings", false);
+  if (request->hasParam("shelly_port", true)) {
+    strncpy(shelly_port, request->getParam("shelly_port", true)->value().c_str(), 5);
+    prefs.putString("shelly_port", shelly_port);
+  }
+  if (request->hasParam("phase_number", true)) {
+    strncpy(phase_number, request->getParam("phase_number", true)->value().c_str(), 1);
+    prefs.putString("phase_number", phase_number);
+  }
+  if (request->hasParam("power_offset", true)) {
+    strncpy(power_offset, request->getParam("power_offset", true)->value().c_str(), 9);
+    prefs.putString("power_offset", power_offset);
+  }
+  if (request->hasParam("query_period", true)) {
+    strncpy(query_period, request->getParam("query_period", true)->value().c_str(), 9);
+    prefs.putString("query_period", query_period);
+  }
+  if (request->hasParam("reset_password", true)) {
+    strncpy(reset_password, request->getParam("reset_password", true)->value().c_str(), 32);
+    prefs.putString("reset_password", reset_password);
+  }
+  prefs.end();
+  String html = "<!DOCTYPE html><html><head><title>Settings Saved</title>";
+  html += "<meta name='viewport' content='width=device-width, initial-scale=1'>";
+  html += "<meta http-equiv='refresh' content='2;url=/settings'>";
+  html += "<style>body{font-family:Arial,sans-serif;text-align:center;padding:50px;}</style></head><body>";
+  html += "<h1>Settings saved!</h1><p>Restarting...</p></body></html>";
+  request->send(200, "text/html", html);
+  delay(1000);
+  ESP.restart();
+}
 
 void setup(void) {
   DEBUG_SERIAL.begin(115200);
@@ -94,6 +156,9 @@ void setup(void) {
     shellyGetStatus();
     request->send(200, "application/json", serJsonResponse);
   });
+
+  server.on("/settings", AsyncWebRequestMethod::HTTP_GET, handleSettingsGet);
+  server.on("/settings", AsyncWebRequestMethod::HTTP_POST, handleSettingsPost);
 
   server.on("/reset", AsyncWebRequestMethod::HTTP_GET, [](AsyncWebServerRequest *request) {
     String html = "<!DOCTYPE html><html><head><title>Reset Confirmation</title>";

--- a/src/web/html_home.h
+++ b/src/web/html_home.h
@@ -42,6 +42,7 @@ const char HTML_HOME[] PROGMEM = R"=====(
   <p>This device emulates a Shelly Pro 3EM to integrate various energy meters.</p>
   <div class="nav">
     <a href="/status">View Status</a>
+    <a href="/settings">Settings</a>
     <a href="/reset" class="reset">Reset Device</a>
   </div>
 


### PR DESCRIPTION
## Summary
- **Watchdog timer** (30s) for automatic crash recovery — device reboots on hang instead of requiring manual reset
- **Web-based settings page** at `/settings` — change Shelly UDP port, phase number, power offset, query period, and reset password without resetting WiFi

## Changes

### Watchdog Timer (`main.cpp`)
- Initialize ESP32 task watchdog in `setup()` BEFORE `WifiManagerSetup()` (catches captive portal hangs)
- Reset watchdog in main loop and during NTP wait loop
- 30s timeout — enough for HTTP requests, catches real hangs

### Settings Page (`main.cpp`, `html_home.h`)
- New `/settings` GET endpoint with HTML form for common settings
- New `/settings` POST endpoint saves to Preferences flash (independent of WiFi config)
- Dashboard gets "Settings" navigation button
- Device restarts after saving to apply changes

Settings available:
- Shelly UDP Port (1010 / 2220 for Marstek Venus)
- Phase Number (1 / 3)
- Power Offset (W)
- Query Period (ms)
- Reset Password

## Motivation
- User experienced overnight crash requiring manual reset → watchdog auto-recovers
- Changing Shelly UDP port (e.g., for different Marstek models) previously required full WiFi reset → now changeable via web UI